### PR TITLE
Stateless LLM, conversation compaction, and async tag extraction

### DIFF
--- a/claude_bridge.py
+++ b/claude_bridge.py
@@ -25,46 +25,33 @@ def call_claude_gm(
     recent_messages: list[dict],
     session_id: str | None = None,
 ) -> tuple[str, str | None]:
-    """Send a player message to Claude GM.
+    """Send a player message to Claude GM (stateless).
 
-    Uses --resume to continue an existing session, or starts a new one
-    with full context on first call.
+    Always uses system prompt + recent context (no --resume).
+    session_id param kept for API compat but ignored.
 
-    Returns (gm_response_text, session_id).
+    Returns (gm_response_text, None).
     """
 
-    if session_id:
-        # Continuing an existing session — label the player's action explicitly
-        # so Claude doesn't echo/paraphrase it before responding
-        prompt = f"【玩家的新行動】\n{user_message}\n\n請直接推進故事，不要複述或改寫玩家的行動內容。"
-        cmd = [
-            CLAUDE_BIN, "-p",
-            "--model", "claude-sonnet-4-5-20250929",
-            "--resume", session_id,
-            "--output-format", "json",
-        ]
-    else:
-        # First call — seed with system prompt + recent context
-        context_lines: list[str] = []
-        for msg in recent_messages:
-            prefix = "【玩家】" if msg["role"] == "user" else "【GM】"
-            context_lines.append(f"{prefix}\n{msg['content']}")
+    context_lines: list[str] = []
+    for msg in recent_messages:
+        prefix = "【玩家】" if msg["role"] == "user" else "【GM】"
+        context_lines.append(f"{prefix}\n{msg['content']}")
 
-        prompt = (
-            "以下是最近的對話紀錄：\n\n"
-            + "\n\n".join(context_lines)
-            + f"\n\n---\n【玩家的新行動】\n{user_message}\n\n"
-            "請以 GM 身份回應，繼續推進故事。"
-        )
-        cmd = [
-            CLAUDE_BIN, "-p",
-            "--model", "claude-sonnet-4-5-20250929",
-            "--system-prompt", system_prompt,
-            "--output-format", "json",
-        ]
+    prompt = (
+        "以下是最近的對話紀錄：\n\n"
+        + "\n\n".join(context_lines)
+        + f"\n\n---\n【玩家的新行動】\n{user_message}\n\n"
+        "請以 GM 身份回應，繼續推進故事。"
+    )
+    cmd = [
+        CLAUDE_BIN, "-p",
+        "--model", "claude-sonnet-4-5-20250929",
+        "--system-prompt", system_prompt,
+        "--output-format", "json",
+    ]
 
-    mode = "resume" if session_id else "new"
-    log.info("    claude_bridge: calling CLI mode=%s prompt_len=%d", mode, len(prompt))
+    log.info("    claude_bridge: calling CLI mode=stateless prompt_len=%d", len(prompt))
     t0 = time.time()
 
     try:
@@ -81,34 +68,33 @@ def call_claude_gm(
         if result.returncode != 0:
             error_msg = result.stderr.strip() or "Unknown error"
             log.info("    claude_bridge: FAILED in %.1fs rc=%d err=%s", elapsed, result.returncode, error_msg[:100])
-            return f"【系統錯誤】Claude 回應失敗：{error_msg}", session_id
+            return f"【系統錯誤】Claude 回應失敗：{error_msg}", None
 
-        # Parse JSON response to extract result text and session_id
+        # Parse JSON response to extract result text
         try:
             data = json.loads(result.stdout)
             response_text = data.get("result", "").strip()
-            new_session_id = data.get("session_id") or session_id
             log.info("    claude_bridge: OK in %.1fs response_len=%d", elapsed, len(response_text))
             if not response_text:
-                return "【系統錯誤】Claude 回傳空白回應", new_session_id
-            return response_text, new_session_id
+                return "【系統錯誤】Claude 回傳空白回應", None
+            return response_text, None
         except json.JSONDecodeError:
             # Fallback: treat stdout as plain text
             text = result.stdout.strip()
             log.info("    claude_bridge: JSON parse failed, fallback plain text in %.1fs", elapsed)
             if text:
-                return text, session_id
-            return "【系統錯誤】無法解析 Claude 回應", session_id
+                return text, None
+            return "【系統錯誤】無法解析 Claude 回應", None
 
     except subprocess.TimeoutExpired:
         log.info("    claude_bridge: TIMEOUT after %ds", CLAUDE_TIMEOUT)
-        return "【系統錯誤】Claude 回應逾時，請稍後再試。", session_id
+        return "【系統錯誤】Claude 回應逾時，請稍後再試。", None
     except FileNotFoundError:
         log.info("    claude_bridge: claude CLI not found")
         return "【系統錯誤】找不到 claude CLI。請確認已安裝 Claude Code。", None
     except Exception as e:
         log.info("    claude_bridge: EXCEPTION %s", e)
-        return f"【系統錯誤】{e}", session_id
+        return f"【系統錯誤】{e}", None
 
 
 # ---------------------------------------------------------------------------
@@ -121,47 +107,37 @@ def call_claude_gm_stream(
     recent_messages: list[dict],
     session_id: str | None = None,
 ):
-    """Stream a GM response from Claude CLI.
+    """Stream a GM response from Claude CLI (stateless).
 
-    Uses --output-format stream-json (NDJSON) with subprocess.Popen.
+    Always uses system prompt + recent context (no --resume).
+    session_id param kept for API compat but ignored.
+
     Yields tuples:
       ("text", delta_str)          — incremental text chunk
-      ("done", {response, session_id})  — final result
+      ("done", {response, session_id})  — final result (session_id always None)
       ("error", msg)               — on failure
     """
 
-    if session_id:
-        # Label the player's action explicitly so Claude doesn't echo/paraphrase it
-        prompt = f"【玩家的新行動】\n{user_message}\n\n請直接推進故事，不要複述或改寫玩家的行動內容。"
-        cmd = [
-            CLAUDE_BIN, "-p",
-            "--verbose",
-            "--model", "claude-sonnet-4-5-20250929",
-            "--resume", session_id,
-            "--output-format", "stream-json",
-        ]
-    else:
-        context_lines: list[str] = []
-        for msg in recent_messages:
-            prefix = "【玩家】" if msg["role"] == "user" else "【GM】"
-            context_lines.append(f"{prefix}\n{msg['content']}")
+    context_lines: list[str] = []
+    for msg in recent_messages:
+        prefix = "【玩家】" if msg["role"] == "user" else "【GM】"
+        context_lines.append(f"{prefix}\n{msg['content']}")
 
-        prompt = (
-            "以下是最近的對話紀錄：\n\n"
-            + "\n\n".join(context_lines)
-            + f"\n\n---\n【玩家的新行動】\n{user_message}\n\n"
-            "請以 GM 身份回應，繼續推進故事。"
-        )
-        cmd = [
-            CLAUDE_BIN, "-p",
-            "--verbose",
-            "--model", "claude-sonnet-4-5-20250929",
-            "--system-prompt", system_prompt,
-            "--output-format", "stream-json",
-        ]
+    prompt = (
+        "以下是最近的對話紀錄：\n\n"
+        + "\n\n".join(context_lines)
+        + f"\n\n---\n【玩家的新行動】\n{user_message}\n\n"
+        "請以 GM 身份回應，繼續推進故事。"
+    )
+    cmd = [
+        CLAUDE_BIN, "-p",
+        "--verbose",
+        "--model", "claude-sonnet-4-5-20250929",
+        "--system-prompt", system_prompt,
+        "--output-format", "stream-json",
+    ]
 
-    mode = "resume" if session_id else "new"
-    log.info("    claude_bridge_stream: calling CLI mode=%s prompt_len=%d", mode, len(prompt))
+    log.info("    claude_bridge_stream: calling CLI mode=stateless prompt_len=%d", len(prompt))
     t0 = time.time()
 
     try:
@@ -194,7 +170,6 @@ def call_claude_gm_stream(
         return
 
     accumulated = ""
-    new_session_id = session_id
 
     try:
         while True:
@@ -227,9 +202,8 @@ def call_claude_gm_stream(
                         yield ("text", delta)
 
             elif msg_type == "result":
-                # Final result — extract session_id and full text
+                # Final result
                 result_text = data.get("result", "").strip()
-                new_session_id = data.get("session_id") or session_id
                 if result_text:
                     # Yield any remaining delta
                     if result_text != accumulated:
@@ -261,7 +235,7 @@ def call_claude_gm_stream(
             yield ("error", "Claude 回傳空白回應")
             return
 
-        yield ("done", {"response": accumulated, "session_id": new_session_id})
+        yield ("done", {"response": accumulated, "session_id": None})
 
     except Exception as e:
         log.info("    claude_bridge_stream: EXCEPTION %s", e)
@@ -270,7 +244,7 @@ def call_claude_gm_stream(
         except Exception:
             pass
         if accumulated:
-            yield ("done", {"response": accumulated, "session_id": new_session_id})
+            yield ("done", {"response": accumulated, "session_id": None})
         else:
             yield ("error", str(e))
 

--- a/compaction.py
+++ b/compaction.py
@@ -1,0 +1,243 @@
+"""Conversation compaction — rolling narrative recap for bounded context.
+
+Replaces unbounded --resume history with:
+  system prompt (with {narrative_recap}) + recent N messages + structured data injections.
+
+Storage: branches/<bid>/conversation_recap.json
+"""
+
+import json
+import logging
+import os
+import threading
+from datetime import datetime, timezone
+
+log = logging.getLogger("rpg")
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+DATA_DIR = os.path.join(BASE_DIR, "data")
+STORIES_DIR = os.path.join(DATA_DIR, "stories")
+
+# Compaction thresholds
+RECAP_CHAR_CAP = 8000          # Max chars for recap text
+RECAP_META_COMPACT_TARGET = 3000  # Target chars when meta-compacting
+MIN_UNCOMPACTED_FOR_TRIGGER = 20  # Need >20 uncompacted msgs to trigger
+RECENT_WINDOW = 20               # Keep last 20 messages as raw context
+
+_FALLBACK_RECAP = "（尚無回顧，完整對話記錄已提供。）"
+
+_COMPACT_PROMPT = """\
+你是故事摘要助手。以下是文字 RPG 遊戲的對話片段。請用繁體中文寫一份 500-800 字的敘事回顧：
+
+1. 關鍵劇情發展（按時間順序）
+2. 玩家的重要決策及後果
+3. 情感轉折與角色發展
+4. 尚未解決的懸念
+
+注意：角色屬性、道具、NPC 資料、世界設定已由其他系統追蹤，不需列出。
+專注於「發生了什麼事」和「故事走向如何」。
+
+{existing_recap}
+
+---
+以下是新的對話內容：
+{messages}
+"""
+
+_META_COMPACT_PROMPT = """\
+你是故事摘要助手。以下是一份 RPG 遊戲的累積敘事回顧，已經太長了。
+請用繁體中文將它重新精煉為約 800 字的版本，保留：
+
+1. 最關鍵的劇情轉折（按時間順序）
+2. 核心角色發展弧線
+3. 仍在進行中的懸念和伏筆
+
+可以省略已解決的小事件和重複的細節。
+
+---
+{recap}
+"""
+
+
+# ---------------------------------------------------------------------------
+# Storage
+# ---------------------------------------------------------------------------
+
+def _recap_path(story_id: str, branch_id: str) -> str:
+    return os.path.join(
+        STORIES_DIR, story_id, "branches", branch_id, "conversation_recap.json"
+    )
+
+
+def _default_recap() -> dict:
+    return {
+        "compacted_through_index": -1,
+        "last_compacted_at": None,
+        "recap_text": "",
+        "total_turns_compacted": 0,
+    }
+
+
+def load_recap(story_id: str, branch_id: str) -> dict:
+    path = _recap_path(story_id, branch_id)
+    if os.path.exists(path):
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    return _default_recap()
+
+
+def save_recap(story_id: str, branch_id: str, data: dict):
+    path = _recap_path(story_id, branch_id)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    tmp = path + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+    os.replace(tmp, path)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def get_recap_text(story_id: str, branch_id: str) -> str:
+    """Return recap text for system prompt injection, or fallback."""
+    recap = load_recap(story_id, branch_id)
+    text = recap.get("recap_text", "").strip()
+    return text if text else _FALLBACK_RECAP
+
+
+def should_compact(recap: dict, timeline_len: int) -> bool:
+    """True when there are >MIN_UNCOMPACTED msgs between compacted_through and recent window."""
+    compacted_through = recap.get("compacted_through_index", -1)
+    recent_start = timeline_len - RECENT_WINDOW
+    uncompacted = recent_start - (compacted_through + 1)
+    return uncompacted > MIN_UNCOMPACTED_FOR_TRIGGER
+
+
+def get_context_window(full_timeline: list[dict]) -> list[dict]:
+    """Return the recent message window for LLM context."""
+    return full_timeline[-RECENT_WINDOW:]
+
+
+def copy_recap_to_branch(
+    story_id: str, from_bid: str, to_bid: str, branch_point_index: int
+):
+    """Copy parent recap to new branch, noting divergence point."""
+    parent_recap = load_recap(story_id, from_bid)
+    if not parent_recap.get("recap_text"):
+        return
+
+    new_recap = dict(parent_recap)
+    # If branching before compacted_through, keep parent recap as-is
+    # (the recap covers the shared history)
+    # If branching after, also fine — recap is still valid for the shared part
+    if branch_point_index >= 0 and parent_recap.get("compacted_through_index", -1) > branch_point_index:
+        # Branch diverges within compacted region — add note
+        new_recap["recap_text"] += "\n\n（注意：以下為分支劇情，從此處開始與主線不同。）"
+
+    save_recap(story_id, to_bid, new_recap)
+
+
+# ---------------------------------------------------------------------------
+# Compaction (background)
+# ---------------------------------------------------------------------------
+
+# Lock per (story_id, branch_id) to prevent concurrent compaction
+_compact_locks: dict[tuple[str, str], threading.Lock] = {}
+_compact_locks_meta = threading.Lock()
+
+
+def _get_lock(story_id: str, branch_id: str) -> threading.Lock:
+    key = (story_id, branch_id)
+    with _compact_locks_meta:
+        if key not in _compact_locks:
+            _compact_locks[key] = threading.Lock()
+        return _compact_locks[key]
+
+
+def _format_messages(messages: list[dict]) -> str:
+    """Format messages for the compaction prompt."""
+    lines = []
+    for msg in messages:
+        prefix = "【玩家】" if msg.get("role") == "user" else "【GM】"
+        content = msg.get("content", "")
+        # Truncate very long messages
+        if len(content) > 1000:
+            content = content[:1000] + "…（略）"
+        lines.append(f"{prefix}\n{content}")
+    return "\n\n".join(lines)
+
+
+def compact_async(story_id: str, branch_id: str, full_timeline: list[dict]):
+    """Trigger background compaction. Non-blocking."""
+    def _do_compact():
+        lock = _get_lock(story_id, branch_id)
+        if not lock.acquire(blocking=False):
+            log.info("    compaction: already running for %s/%s, skipping", story_id, branch_id)
+            return
+        try:
+            _run_compaction(story_id, branch_id, full_timeline)
+        except Exception as e:
+            log.info("    compaction: EXCEPTION %s", e)
+        finally:
+            lock.release()
+
+    t = threading.Thread(target=_do_compact, daemon=True)
+    t.start()
+
+
+def _run_compaction(story_id: str, branch_id: str, full_timeline: list[dict]):
+    """Actually perform compaction (runs in background thread)."""
+    from llm_bridge import call_oneshot
+
+    recap = load_recap(story_id, branch_id)
+    compacted_through = recap.get("compacted_through_index", -1)
+
+    # Messages to compact: from compacted_through+1 to len-RECENT_WINDOW
+    compact_end = len(full_timeline) - RECENT_WINDOW
+    if compact_end <= compacted_through + 1:
+        return  # Nothing to compact
+
+    msgs_to_compact = full_timeline[compacted_through + 1 : compact_end]
+    if not msgs_to_compact:
+        return
+
+    log.info("    compaction: summarizing %d messages (idx %d-%d) for %s/%s",
+             len(msgs_to_compact), compacted_through + 1, compact_end - 1,
+             story_id, branch_id)
+
+    existing_recap = ""
+    if recap.get("recap_text"):
+        existing_recap = f"以下是先前的敘事回顧（請在此基礎上延續）：\n\n{recap['recap_text']}"
+
+    prompt = _COMPACT_PROMPT.format(
+        existing_recap=existing_recap,
+        messages=_format_messages(msgs_to_compact),
+    )
+
+    new_recap_text = call_oneshot(prompt)
+    if not new_recap_text:
+        log.info("    compaction: LLM returned empty, aborting")
+        return
+
+    new_recap_text = new_recap_text.strip()
+
+    # Check if meta-compaction needed (recap too long)
+    if len(new_recap_text) > RECAP_CHAR_CAP:
+        log.info("    compaction: recap too long (%d chars), meta-compacting", len(new_recap_text))
+        meta_prompt = _META_COMPACT_PROMPT.format(recap=new_recap_text)
+        meta_result = call_oneshot(meta_prompt)
+        if meta_result and meta_result.strip():
+            new_recap_text = meta_result.strip()
+            log.info("    compaction: meta-compacted to %d chars", len(new_recap_text))
+
+    turn_count = sum(1 for m in msgs_to_compact if m.get("role") == "user")
+
+    recap["recap_text"] = new_recap_text
+    recap["compacted_through_index"] = compact_end - 1
+    recap["last_compacted_at"] = datetime.now(timezone.utc).isoformat()
+    recap["total_turns_compacted"] = recap.get("total_turns_compacted", 0) + turn_count
+
+    save_recap(story_id, branch_id, recap)
+    log.info("    compaction: done — recap=%d chars, compacted_through=%d",
+             len(new_recap_text), compact_end - 1)

--- a/event_db.py
+++ b/event_db.py
@@ -176,6 +176,18 @@ def search_relevant_events(story_id: str, user_message: str, branch_id: str, lim
     return "\n".join(lines)
 
 
+def get_event_titles(story_id: str, branch_id: str) -> set[str]:
+    """Return set of existing event titles for dedup."""
+    conn = _get_conn(story_id)
+    _ensure_tables(conn)
+    rows = conn.execute(
+        "SELECT title FROM events WHERE branch_id = ?", (branch_id,)
+    ).fetchall()
+    titles = {r["title"] for r in rows}
+    conn.close()
+    return titles
+
+
 def get_active_foreshadowing(story_id: str, branch_id: str) -> list[dict]:
     """Get planted events not yet triggered for a branch."""
     conn = _get_conn(story_id)

--- a/prompts.py
+++ b/prompts.py
@@ -46,35 +46,7 @@ SYSTEM_PROMPT_TEMPLATE = """\
 ## 故事摘要（到目前為止）
 {story_summary}
 
-## 角色狀態更新
-每次回覆如果涉及角色狀態變化（道具增減、獎勵點花費/獲得、體質變化、基因鎖進度、任務完成、人際關係變動等），請在回覆**最末尾**附上結構化狀態 tag，格式如下：
-
-<!--STATE
-{{
-  "inventory_add": ["新道具名"],
-  "inventory_remove": ["失去的道具名"],
-  "reward_points_delta": -500,
-  "gene_lock": "第一階（進度 30%）",
-  "physique": "強化人類",
-  "spirit": "中等偏上",
-  "current_status": "主神空間休整中",
-  "completed_missions_add": ["新任務名"],
-  "relationships": {{"小薇": "戀人/深厚信任"}}
-}}
-STATE-->
-
-規則：
-- 所有欄位**皆為選填**，只寫有變化的欄位即可。
-- 沒有任何狀態變化時**不要**附 tag。
-- `inventory_add` / `inventory_remove`：陣列，道具名稱需含數量標記（如「鎮魂符×1」）。
-- `reward_points_delta`：整數，正數=獲得，負數=花費。
-- `completed_missions_add`：陣列，新完成的任務名。
-- `relationships`：物件，只寫有變動的角色，值為新的關係描述。
-- `gene_lock`、`physique`、`spirit`、`current_status`：字串，直接覆蓋舊值。
-- 此 tag 不會顯示給玩家看，純供系統解析用。
-
 ## 重要指示
-- 你是從 Grok GM 手中接過這場遊戲的。玩家角色 Eddy 剛完成《咒怨》任務，帶著 5000 獎勵點即將返回主神空間。
 - 保持故事連續性：角色關係、已獲道具、劇情伏筆都要延續。
 - 戰鬥和危險場景要有張力，但給玩家合理的應對空間。
 - 角色互動要有溫度：NPC 有各自的性格和動機。


### PR DESCRIPTION
## Summary

Three interconnected improvements that make the RPG backend more reliable and the GM output higher quality:

- **Stateless LLM calls**: Remove `--resume` session management — every call sends system prompt + recent 20 messages, eliminating session state bugs
- **Conversation compaction** (`compaction.py`): Rolling narrative recap via background LLM call, injected as `{narrative_recap}` placeholder in system prompt
- **Async tag extraction** (`_extract_tags_async`): Post-processing LLM call extracts structured data (lore/events/npcs/state) from GM narrative in a background thread — GM no longer needs to output `<!--STATE-->` / `<!--LORE-->` / `<!--NPC-->` / `<!--EVENT-->` tags

## Data Flow

```
┌─────────────────────────────────────────────────────────────┐
│                     Player sends message                     │
└─────────────┬───────────────────────────────────────────────┘
              │
              ▼
┌─────────────────────────────────────────────────────────────┐
│  _build_augmented_message()                                  │
│  ┌──────────────┐ ┌──────────────┐ ┌──────────────────────┐ │
│  │ Lore search  │ │ Event search │ │ NPC activities + Dice│ │
│  └──────────────┘ └──────────────┘ └──────────────────────┘ │
└─────────────┬───────────────────────────────────────────────┘
              │
              ▼
┌─────────────────────────────────────────────────────────────┐
│  _build_story_system_prompt()                                │
│  system_prompt.txt + {character_state} + {narrative_recap}   │
│  + {world_lore} + {npc_profiles}                             │
└─────────────┬───────────────────────────────────────────────┘
              │
              ▼
┌─────────────────────────────────────────────────────────────┐
│  call_claude_gm()  [STATELESS]                               │
│  system_prompt + recent 20 messages + augmented user msg     │
│  (no --resume, no session_id)                                │
└─────────────┬───────────────────────────────────────────────┘
              │
              ▼
┌─────────────────────────────────────────────────────────────┐
│  _process_gm_response()                                      │
│                                                              │
│  1. Regex safety net: extract STATE/LORE/NPC/EVENT/IMG tags  │
│     (kept for backward compat if GM still outputs them)      │
│                                                              │
│  2. _extract_tags_async() ──► background thread              │
│     ┌────────────────────────────────────────────────────┐   │
│     │  call_oneshot() with extraction prompt              │   │
│     │  ┌──────────┐ ┌────────┐ ┌──────┐ ┌─────────┐    │   │
│     │  │  Lore    │ │ Events │ │ NPCs │ │  State  │    │   │
│     │  │ (dedup   │ │(dedup  │ │(merge│ │ (apply  │    │   │
│     │  │  topic)  │ │ title) │ │ name)│ │ update) │    │   │
│     │  └──────────┘ └────────┘ └──────┘ └─────────┘    │   │
│     └────────────────────────────────────────────────────┘   │
│                                                              │
│  3. compact_async() ──► background thread (if due)           │
│     ┌────────────────────────────────────────────────────┐   │
│     │  Summarize recent messages → narrative_recap.json   │   │
│     └────────────────────────────────────────────────────┘   │
└─────────────────────────────────────────────────────────────┘
```

## Why

| Problem | Solution |
|---------|----------|
| GM outputs 50+ junk STATE fields (location, threat_level, etc.) | Extraction prompt limits to schema-defined fields |
| GM never outputs LORE/NPC/EVENT tags | Post-processing extracts them reliably |
| `--resume` sessions break on context overflow | Stateless calls with explicit context window |
| Long conversations lose early context | Rolling narrative recap via compaction |

## Files Changed

| File | Change |
|------|--------|
| `app.py` | +`_extract_tags_async()`, compaction integration, `narrative_recap` placeholder |
| `compaction.py` | New: rolling narrative recap with background LLM summarization |
| `claude_bridge.py` | Simplified to stateless mode (removed `--resume` logic) |
| `auto_play.py` | Stateless calls + compaction trigger after each turn |
| `event_db.py` | +`get_event_titles()` for event dedup |
| `prompts.py` | Removed STATE tag instructions from fallback template |
| `system_prompt.txt` | Removed STATE/LORE/NPC/EVENT sections (gitignored, per-story data) |

## Dedup Strategy

| Type | Dedup |
|------|-------|
| **Lore** | `topic not in existing_topics` + prompt includes TOC |
| **Events** | `title not in existing_titles` + prompt includes titles |
| **NPCs** | `_save_npc()` built-in merge-by-name |
| **State** | Schema-constrained fields, delta-based updates are idempotent |

## Test plan

- [ ] Run server, play a few turns → check logs for `extract_tags: saved N lore, N events, N npcs, state updated`
- [ ] Verify `world_lore.json` has new entries, `events.db` has new events
- [ ] Verify existing manually-created lore entries are not overwritten
- [ ] Run auto-play 10+ turns → confirm lore/event/npc data grows consistently
- [ ] Verify GM responses no longer contain `<!--STATE-->` tags, narrative quality improves
- [ ] Verify compaction triggers and `narrative_recap.json` is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)