### PR TITLE
Merge feature/multi-agent with bug fixes into main

### DIFF
--- a/auto_play.py
+++ b/auto_play.py
@@ -441,8 +441,8 @@ def execute_turn(
     # 11. Trigger compaction if due
     recap = load_recap(story_id, branch_id)
     if should_compact(recap, len(full_timeline) + 1):
-        full_timeline.append(gm_msg)
-        compact_async(story_id, branch_id, full_timeline)
+        tl = list(full_timeline) + [gm_msg]
+        compact_async(story_id, branch_id, tl)
 
     return gm_response
 


### PR DESCRIPTION
## Summary
Merge `feature/multi-agent` into `main`, bringing in PR #3 bug fixes that were merged into the feature branch:

- Fix `_extract_tags_async`: `skip_state` param prevents STATE delta double-apply
- Fix `compact_async`: pass timeline copy instead of reference in all routes
- Add JSON parse `re.search` fallback for LLM responses wrapped in markdown
- Add compaction triggers to all 4 edit/regen routes (previously only send routes)
- Deduplicate `RECENT_MESSAGE_COUNT` — import from `compaction.py`
- Upgrade error logging in `_extract_tags_async`

## Test plan
- [x] All items verified in PR #3 review

🤖 Generated with [Claude Code](https://claude.com/claude-code)