### PR TITLE
Fix character name hallucination in summaries

### DIFF
--- a/story_utils.py
+++ b/story_utils.py
@@ -1,0 +1,18 @@
+"""Shared utilities for story data access."""
+
+import json
+import os
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+STORIES_DIR = os.path.join(BASE_DIR, "data", "stories")
+
+
+def get_character_name(story_id: str, branch_id: str) -> str:
+    """Read player character name from branch character_state.json."""
+    path = os.path.join(STORIES_DIR, story_id, "branches", branch_id, "character_state.json")
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            state = json.load(f)
+        return state.get("name", "玩家")
+    except (FileNotFoundError, json.JSONDecodeError):
+        return "玩家"


### PR DESCRIPTION
## Summary
- Both `auto_summary.py` and `compaction.py` were generating summaries without telling the LLM the player character's name
- The LLM hallucinated Chinese names (林浩/林皓/林陽/林昊) instead of the actual name "Eddy" from `character_state.json`
- Added `_get_character_name()` helper to both modules that reads from `branches/<bid>/character_state.json`
- Injected character name into LLM prompts with explicit instructions to use it consistently

## Root Cause
The summarization prompts tagged messages as 【玩家】/【GM】 but never specified who the player character actually is. Since all NPCs had Chinese names (林毅, 蘇凜, 阿豪), the LLM assumed the player also had a Chinese name and hallucinated different variants each time.

## Test plan
- [ ] Run auto-play and verify `auto_play_summaries.json` consistently uses the correct player name
- [ ] Trigger conversation compaction and verify `conversation_recap.json` uses the correct name in 3rd person
- [ ] Verify fallback to "玩家" if `character_state.json` is missing or has no `name` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)