### PR TITLE
Auto-cleanup failed branches + sibling delete button

### DIFF
--- a/app.py
+++ b/app.py
@@ -1907,9 +1907,14 @@ def api_branches_edit():
     log.info("  context_search: %.0fms", (time.time() - t0) * 1000)
 
     t0 = time.time()
-    gm_response, _ = call_claude_gm(
-        augmented_edit, system_prompt, recent, session_id=None
-    )
+    try:
+        gm_response, _ = call_claude_gm(
+            augmented_edit, system_prompt, recent, session_id=None
+        )
+    except Exception as e:
+        log.info("/api/branches/edit EXCEPTION %s", e)
+        _cleanup_branch(story_id, branch_id)
+        return jsonify({"ok": False, "error": str(e)}), 500
     log.info("  claude_call: %.1fs", time.time() - t0)
 
     gm_response, image_info, snapshots = _process_gm_response(gm_response, story_id, branch_id, gm_msg_index)
@@ -2141,9 +2146,14 @@ def api_branches_regenerate():
     log.info("  context_search: %.0fms", (time.time() - t0) * 1000)
 
     t0 = time.time()
-    gm_response, _ = call_claude_gm(
-        augmented_regen, system_prompt, recent, session_id=None
-    )
+    try:
+        gm_response, _ = call_claude_gm(
+            augmented_regen, system_prompt, recent, session_id=None
+        )
+    except Exception as e:
+        log.info("/api/branches/regenerate EXCEPTION %s", e)
+        _cleanup_branch(story_id, branch_id)
+        return jsonify({"ok": False, "error": str(e)}), 500
     log.info("  claude_call: %.1fs", time.time() - t0)
 
     gm_msg_index = branch_point_index + 1

--- a/static/style.css
+++ b/static/style.css
@@ -1706,6 +1706,9 @@ body {
     padding: 4px 10px;
     font-size: 0.85rem;
   }
+  .sw-delete {
+    opacity: 0.5;
+  }
 
   /* Action buttons */
   .msg-action-btn {


### PR DESCRIPTION
## Summary
- **Auto-cleanup failed branches**: Edit (✎) / Regen (↻) create a new branch before calling LLM. If the LLM call fails (e.g. Gemini key cooldown), the empty branch is now automatically deleted instead of lingering as a dead stub.
- **Sibling switcher ✕ button**: Hover over the `< 1/N >` switcher to reveal a ✕ button that deletes the current variant (with confirmation). Automatically switches to adjacent sibling after deletion.
- **Error callback branch reload**: Edit/regen error handlers now refresh the branch list so the drawer reflects cleanup immediately.

## Test plan
- [ ] Edit a message when LLM is down → verify no dead branch remains in branch tree
- [ ] Regen a GM response when LLM is down → same verification
- [ ] Hover over `< 1/2 >` switcher → ✕ appears
- [ ] Click ✕ → confirm → variant deleted, switches to adjacent sibling
- [ ] Verify ✕ does NOT appear on main branch variants
- [ ] Verify ✕ does NOT appear when only 1 variant exists (switcher hidden)
- [ ] Send a message when LLM is down → user message preserved (no cleanup, expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)