### PR TITLE
Add lore source provenance with deep-link

### DIFF
--- a/app.py
+++ b/app.py
@@ -2793,7 +2793,7 @@ def api_lore_entry_update():
                     return jsonify({"ok": False, "error": f"topic '{new_topic}' already exists"}), 409
                 delete_lore_entry(story_id, topic)
             updated = {"category": new_category, "topic": new_topic, "content": new_content}
-            if e.get("source"):
+            if "source" in e:
                 updated["source"] = e["source"]
             lore[i] = updated
             _save_json(_story_lore_path(story_id), lore)

--- a/static/app.js
+++ b/static/app.js
@@ -470,8 +470,26 @@ async function init() {
     updateInitStatus("載入角色與事件…");
     await Promise.all([loadNpcs(), loadEvents(), loadSummaries()]);
 
+    // Handle URL params: ?branch=BRANCH_ID&msg=MSG_INDEX (from lore console)
+    const urlParams = new URLSearchParams(window.location.search);
+    const paramBranch = urlParams.get("branch");
+    const paramMsgRaw = urlParams.get("msg");
+    const paramMsg = paramMsgRaw != null ? parseInt(paramMsgRaw, 10) : NaN;
+    if (paramBranch && paramBranch !== currentBranchId) {
+      await switchToBranch(paramBranch, {
+        scrollToIndex: !isNaN(paramMsg) ? paramMsg : undefined,
+        scrollBlock: "center",
+      });
+      // Clean URL without reloading
+      window.history.replaceState({}, "", "/");
+    } else if (!isNaN(paramMsg) && paramMsg >= 0) {
+      const target = document.querySelector(`.message[data-index="${paramMsg}"]`);
+      if (target) target.scrollIntoView({ block: "center" });
+      window.history.replaceState({}, "", "/");
+    }
+
     removeInitOverlay();
-    scrollToBottom();
+    if (!paramBranch && isNaN(paramMsg)) scrollToBottom();
 
     // Show "load earlier" button for auto branches with truncated messages
     if (isAutoBranch(currentBranchId) && allMessages.length < totalMessages) {

--- a/static/lore.css
+++ b/static/lore.css
@@ -281,7 +281,13 @@ body.lore-page {
   font-size: 0.75rem;
   color: var(--text-dim);
   margin-top: 4px;
-  opacity: 0.7;
+}
+.lore-entry-source a {
+  color: var(--accent);
+  text-decoration: none;
+}
+.lore-entry-source a:hover {
+  text-decoration: underline;
 }
 
 /* Source info in edit modal */
@@ -296,11 +302,17 @@ body.lore-page {
   border: 1px solid var(--border);
   border-radius: var(--radius);
 }
+.modal-source-link {
+  color: var(--accent);
+  text-decoration: none;
+}
+.modal-source-link:hover {
+  text-decoration: underline;
+}
 .modal-source-excerpt {
   margin-top: 4px;
   font-size: 0.78rem;
   color: var(--text-dim);
-  opacity: 0.7;
   line-height: 1.4;
 }
 

--- a/static/lore.js
+++ b/static/lore.js
@@ -163,6 +163,13 @@
     return parts.join(" · ");
   }
 
+  function buildSourceUrl(source) {
+    if (!source || !source.branch_id) return null;
+    let url = `/?branch=${encodeURIComponent(source.branch_id)}`;
+    if (source.msg_index != null) url += `&msg=${source.msg_index}`;
+    return url;
+  }
+
   function renderEntryHtml(e, displayName) {
     const label = displayName || e.topic;
     const sel = e.topic === selectedTopic ? " selected" : "";
@@ -173,7 +180,13 @@
     const previewText = sel ? e.content || "" : truncate(e.content, 120);
     html += `<div class="lore-entry-preview">${escapeHtml(previewText)}`;
     if (e.source) {
-      html += `<div class="lore-entry-source">來源：${escapeHtml(formatSourceLine(e.source))}</div>`;
+      const srcUrl = buildSourceUrl(e.source);
+      const srcText = escapeHtml(formatSourceLine(e.source));
+      if (srcUrl) {
+        html += `<div class="lore-entry-source"><a href="${escapeHtml(srcUrl)}" target="_blank" title="跳轉到原始對話">來源：${srcText}</a></div>`;
+      } else {
+        html += `<div class="lore-entry-source">來源：${srcText}</div>`;
+      }
     }
     html += `</div>`;
     return html;
@@ -320,9 +333,14 @@
         const srcDiv = document.createElement("div");
         srcDiv.id = "modal-source-info";
         srcDiv.className = "modal-source-info";
+        const srcUrl = buildSourceUrl(entry.source);
         let srcHtml = `<label>來源</label>`;
         srcHtml += `<div class="modal-source-detail">`;
-        srcHtml += `<span>${escapeHtml(formatSourceLine(entry.source))}</span>`;
+        if (srcUrl) {
+          srcHtml += `<a href="${escapeHtml(srcUrl)}" target="_blank" class="modal-source-link" title="跳轉到原始對話">${escapeHtml(formatSourceLine(entry.source))} ↗</a>`;
+        } else {
+          srcHtml += `<span>${escapeHtml(formatSourceLine(entry.source))}</span>`;
+        }
         if (entry.source.excerpt) {
           srcHtml += `<div class="modal-source-excerpt">「${escapeHtml(entry.source.excerpt)}」</div>`;
         }


### PR DESCRIPTION
## Summary
- Track origin of auto-extracted lore entries with `source: {branch_id, msg_index, excerpt, timestamp}`
- Source injected at both extraction paths (regex fallback + async LLM) and preserved on manual edits
- Clickable deep-link in lore console → opens game page at exact branch + message (`?branch=X&msg=N`)
- URL param handler in `app.js` init: reads `branch` + `msg`, calls `switchToBranch` with `scrollToIndex`
- Source excluded from LLM prompts (naturally — all injection paths only read topic/content/category)

## Files changed
| File | Change |
|------|--------|
| `app.py` | `_save_lore_entry` preserve source; inject source in `_extract_tags_async` + `_process_gm_response`; preserve source in PUT `/api/lore/entry` |
| `static/app.js` | URL param deep-link handler (`?branch=X&msg=N`) with integer validation |
| `static/lore.js` | `formatSourceLine()`, `buildSourceUrl()`, clickable links in preview + edit modal |
| `static/lore.css` | Source line + modal source styling |

## Test plan
- [ ] Send a message to trigger GM response → check `world_lore.json` for new entries with `source`
- [ ] Open `/lore`, verify source line appears on entries with source (not on legacy)
- [ ] Click source link → verify game page opens at correct branch + message
- [ ] Edit a lore entry via modal → verify `source` is preserved after save
- [ ] Verify LLM prompt does not contain `source` (check server logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)