### PR TITLE
Improve lore page UX: batch delete, markdown chat, streaming controls

### DIFF
--- a/static/lore.css
+++ b/static/lore.css
@@ -218,6 +218,36 @@ body.lore-page {
   padding-left: 42px;
 }
 
+/* Batch action bar */
+.batch-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  background: #3a2d2d;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+  font-size: 0.82rem;
+}
+.batch-bar.hidden { display: none; }
+.batch-bar #batch-count {
+  color: #db7f7f;
+  font-weight: 600;
+  margin-right: auto;
+}
+.batch-bar .btn-danger { padding: 4px 12px; font-size: 0.8rem; }
+.batch-bar .btn-secondary { padding: 4px 12px; font-size: 0.8rem; }
+
+/* Entry checkbox */
+.lore-entry-check {
+  width: 15px;
+  height: 15px;
+  margin-right: 6px;
+  cursor: pointer;
+  accent-color: var(--accent);
+  flex-shrink: 0;
+}
+
 .lore-entry {
   display: flex;
   align-items: center;
@@ -336,9 +366,27 @@ body.lore-page {
 .chat-msg-content {
   font-size: 0.9rem;
   line-height: 1.6;
-  white-space: pre-wrap;
   word-break: break-word;
 }
+.chat-msg.user .chat-msg-content {
+  white-space: pre-wrap;
+}
+
+/* Markdown styles in chat */
+.chat-msg-content p { margin: 0 0 0.5em 0; }
+.chat-msg-content p:last-child { margin-bottom: 0; }
+.chat-msg-content ul, .chat-msg-content ol { margin: 0.3em 0; padding-left: 1.5em; }
+.chat-msg-content li { margin: 0.2em 0; }
+.chat-msg-content strong { color: var(--gold); }
+.chat-msg-content em { font-style: italic; }
+.chat-msg-content code { background: var(--input-bg); padding: 1px 5px; border-radius: 3px; font-size: 0.85em; }
+.chat-msg-content pre { background: var(--input-bg); padding: 10px; border-radius: var(--radius); overflow-x: auto; margin: 0.5em 0; white-space: pre-wrap; }
+.chat-msg-content pre code { padding: 0; background: none; }
+.chat-msg-content blockquote { border-left: 3px solid var(--accent); padding-left: 10px; margin: 0.5em 0; color: var(--text-dim); }
+.chat-msg-content h1, .chat-msg-content h2, .chat-msg-content h3 { color: var(--gold); margin: 0.5em 0 0.3em; }
+.chat-msg-content h1 { font-size: 1.1em; }
+.chat-msg-content h2 { font-size: 1em; }
+.chat-msg-content h3 { font-size: 0.95em; }
 
 /* Proposal cards */
 .proposal-cards {
@@ -480,6 +528,23 @@ body.lore-page {
 #chat-send-btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+#chat-stop-btn {
+  padding: 8px 14px;
+  background: #5a2d2d;
+  color: #db7f7f;
+  border: 1px solid #6b3333;
+  border-radius: var(--radius);
+  font-size: 0.9rem;
+  cursor: pointer;
+  align-self: flex-end;
+}
+#chat-stop-btn:hover {
+  background: #6b3333;
+}
+#chat-stop-btn.hidden {
+  display: none;
 }
 
 /* ---------- Modal ---------- */

--- a/templates/lore.html
+++ b/templates/lore.html
@@ -33,6 +33,11 @@
         <button id="lore-toggle-all-btn" title="全部展開/收起">&#x25BC;</button>
         <button id="lore-add-btn" title="新增設定">+ 新增</button>
       </div>
+      <div id="batch-bar" class="batch-bar hidden">
+        <span id="batch-count"></span>
+        <button id="batch-delete-btn" class="btn-danger">刪除所選</button>
+        <button id="batch-clear-btn" class="btn-secondary">取消選取</button>
+      </div>
       <div id="lore-list" class="panel-body">
         <!-- Populated by JS -->
       </div>
@@ -42,17 +47,12 @@
     <div id="lore-chat-panel" class="panel hidden-mobile">
       <div id="chat-messages" class="panel-body">
         <div class="chat-msg assistant">
-          <div class="chat-msg-content">歡迎使用世界設定管理助手。你可以：
-• 詢問現有設定的細節或矛盾
-• 請我幫你新增、修改或刪除設定
-• 討論設定間的一致性
-
-變更會即時同步到遊戲中，影響 GM 的下一次回覆。
-有什麼我能幫忙的嗎？</div>
+          <div class="chat-msg-content"><p>歡迎使用世界設定管理助手。你可以：</p><ul><li>詢問現有設定的細節或矛盾</li><li>請我幫你新增、修改或刪除設定</li><li>討論設定間的一致性</li></ul><p>變更會即時同步到遊戲中，影響 GM 的下一次回覆。<br>有什麼我能幫忙的嗎？</p></div>
         </div>
       </div>
       <div id="chat-input-area">
-        <textarea id="chat-input" placeholder="輸入訊息..." rows="2"></textarea>
+        <textarea id="chat-input" placeholder="輸入訊息... (Ctrl+Enter 送出)" rows="2"></textarea>
+        <button id="chat-stop-btn" class="hidden" title="停止輸出">停止</button>
         <button id="chat-send-btn" title="送出">送出</button>
       </div>
     </div>
@@ -83,6 +83,8 @@
     </div>
   </div>
 
+  <script src="https://cdn.jsdelivr.net/npm/dompurify@3.2.4/dist/purify.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/marked@15.0.7/marked.min.js"></script>
   <script src="/static/lore.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- **Clear chat input** after send + refocus textarea
- **Checkbox batch delete** — each lore entry gets a checkbox, batch bar with count, confirmation dialog showing entry names, per-entry error tracking
- **Multiple entry expansion** — selecting a new entry no longer collapses the previous one (Set-based `selectedTopics`)
- **Cmd/Ctrl+Enter to send** — platform-aware hint (⌘ on Mac, Ctrl on others)
- **Stop button** — abort LLM streaming mid-response via AbortController
- **Markdown rendering** — AI chat responses rendered with marked.js + DOMPurify (pinned CDN versions), with throttled streaming updates (120ms) and safe fallback to `escapeHtml()` if either library fails to load
- Aborted responses excluded from LLM context history
- Stale selections pruned on list refresh

## Test plan
- [ ] Open `/lore` page, verify entries load with checkboxes
- [ ] Select multiple checkboxes → batch bar appears with correct count → delete with confirmation
- [ ] Click entries → multiple can be expanded simultaneously
- [ ] Type in chat → Enter creates newline, Cmd/Ctrl+Enter sends
- [ ] Verify chat input clears and refocuses after send
- [ ] During streaming, click "停止" → response stops, marked as aborted
- [ ] Verify markdown renders in assistant messages (bold, lists, code blocks)
- [ ] Test on mobile: tabs switch correctly, batch bar visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)