### PR TITLE
feat: implement Debug Panel V1 (debug chat/apply/undo/directive)

### DIFF
--- a/app.py
+++ b/app.py
@@ -7590,8 +7590,8 @@ def api_debug_chat_stream():
                     display_text, proposals = _extract_debug_action_tags(response_raw)
                     display_text, directives = _extract_debug_directive_tags(display_text)
                     display_text = display_text.strip()
-                    if display_text:
-                        _append_debug_chat_message(story_id, debug_unit_id, "assistant", display_text)
+                    if response_raw:
+                        _append_debug_chat_message(story_id, debug_unit_id, "assistant", response_raw)
                     done_payload = {
                         "type": "done",
                         "response": display_text,

--- a/app.py
+++ b/app.py
@@ -1357,6 +1357,7 @@ _EVENT_RE = re.compile(_TAG_OPEN + r"EVENT\s*(.*?)\s*EVENT" + _TAG_CLOSE, re.DOT
 _IMG_RE = re.compile(_TAG_OPEN + r"IMG\s+prompt:\s*(.*?)\s*IMG" + _TAG_CLOSE, re.DOTALL)
 _DEBUG_ACTION_RE = re.compile(r"<!--DEBUG_ACTION\s*(.*?)\s*DEBUG_ACTION-->", re.DOTALL)
 _DEBUG_DIRECTIVE_RE = re.compile(r"<!--DEBUG_DIRECTIVE\s*(.*?)\s*DEBUG_DIRECTIVE-->", re.DOTALL)
+_DEBUG_ACTION_TYPES = {"state_patch", "npc_upsert", "npc_delete", "world_day_set", "dungeon_patch"}
 
 
 def _extract_state_tag(text: str) -> tuple[str, list[dict]]:
@@ -1447,8 +1448,9 @@ def _extract_debug_action_tags(text: str) -> tuple[str, list[dict]]:
             break
         try:
             payload = json.loads(m.group(1))
-            if isinstance(payload, dict):
-                actions.append(payload)
+            normalized = _normalize_debug_action_payload(payload)
+            if isinstance(normalized, dict):
+                actions.append(normalized)
         except (json.JSONDecodeError, ValueError):
             pass
         text = text[: m.start()].rstrip() + text[m.end():]
@@ -1474,6 +1476,120 @@ def _extract_debug_directive_tags(text: str) -> tuple[str, list[dict]]:
         text = text[: m.start()].rstrip() + text[m.end():]
         text = text.strip()
     return text, directives
+
+
+def _normalize_debug_action_payload(payload: object) -> dict | None:
+    """Normalize model-emitted debug action payloads into canonical action objects."""
+    if not isinstance(payload, dict):
+        return None
+
+    data = dict(payload)
+    nested_action = data.get("action")
+    if isinstance(nested_action, dict):
+        nested = _normalize_debug_action_payload(nested_action)
+        if nested:
+            return nested
+
+    action_type = str(data.get("type") or data.get("action_type") or data.get("kind") or "").strip()
+    if action_type in _DEBUG_ACTION_TYPES:
+        normalized = dict(data)
+        normalized["type"] = action_type
+        payload_obj = normalized.get("payload")
+        if isinstance(payload_obj, dict):
+            for k, v in payload_obj.items():
+                normalized.setdefault(k, v)
+
+        if action_type == "state_patch":
+            state_obj = normalized.get("state_patch")
+            if not isinstance(normalized.get("update"), dict):
+                if isinstance(state_obj, dict):
+                    normalized["update"] = state_obj
+                else:
+                    extras = {
+                        k: v for k, v in normalized.items()
+                        if k not in {"type", "action_type", "kind", "payload", "state_patch"}
+                    }
+                    if extras:
+                        normalized["update"] = extras
+        elif action_type == "npc_upsert":
+            npc_obj = normalized.get("npc_upsert")
+            if not isinstance(normalized.get("npc"), dict) and isinstance(npc_obj, dict):
+                normalized["npc"] = npc_obj
+        elif action_type == "npc_delete":
+            if not str(normalized.get("npc_id", "")).strip():
+                npc_delete_val = normalized.get("npc_delete")
+                if isinstance(npc_delete_val, str) and npc_delete_val.strip():
+                    normalized["npc_id"] = npc_delete_val.strip()
+        elif action_type == "world_day_set":
+            if "world_day" not in normalized and "value" in normalized:
+                normalized["world_day"] = normalized.get("value")
+        elif action_type == "dungeon_patch":
+            dungeon_obj = normalized.get("dungeon_patch")
+            if isinstance(dungeon_obj, dict):
+                for k, v in dungeon_obj.items():
+                    normalized.setdefault(k, v)
+        return normalized
+
+    if isinstance(data.get("update"), dict):
+        return {"type": "state_patch", "update": data["update"]}
+
+    if "world_day" in data:
+        return {"type": "world_day_set", "world_day": data.get("world_day")}
+
+    if isinstance(data.get("npc"), dict):
+        return {"type": "npc_upsert", "npc": data["npc"]}
+
+    npc_id = str(data.get("npc_id", "")).strip()
+    if npc_id:
+        return {"type": "npc_delete", "npc_id": npc_id}
+
+    dungeon_keys = {"progress_delta", "mainline_progress_delta", "completed_nodes", "discovered_areas", "explored_area_updates"}
+    if any(k in data for k in dungeon_keys):
+        out = {"type": "dungeon_patch"}
+        for k in dungeon_keys:
+            if k in data:
+                out[k] = data[k]
+        return out
+
+    for key in _DEBUG_ACTION_TYPES:
+        if key not in data:
+            continue
+        value = data.get(key)
+        if key == "state_patch":
+            if isinstance(value, dict):
+                if isinstance(value.get("update"), dict):
+                    return {"type": "state_patch", "update": value["update"]}
+                return {"type": "state_patch", "update": value}
+            return None
+        if key == "npc_upsert":
+            if isinstance(value, dict):
+                if isinstance(value.get("npc"), dict):
+                    return {"type": "npc_upsert", "npc": value["npc"]}
+                return {"type": "npc_upsert", "npc": value}
+            return None
+        if key == "npc_delete":
+            if isinstance(value, dict):
+                nested_id = str(value.get("npc_id", "")).strip()
+                if nested_id:
+                    return {"type": "npc_delete", "npc_id": nested_id}
+                return None
+            if isinstance(value, str) and value.strip():
+                return {"type": "npc_delete", "npc_id": value.strip()}
+            return None
+        if key == "world_day_set":
+            if isinstance(value, dict) and "world_day" in value:
+                return {"type": "world_day_set", "world_day": value.get("world_day")}
+            return {"type": "world_day_set", "world_day": value}
+        if key == "dungeon_patch":
+            if isinstance(value, dict):
+                out = {"type": "dungeon_patch"}
+                for k in dungeon_keys:
+                    if k in value:
+                        out[k] = value[k]
+                return out
+            return None
+
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -7096,6 +7212,9 @@ def _pick_latest_debug_directive(directives: object) -> dict | None:
 
 
 def _apply_debug_action(story_id: str, branch_id: str, action: dict) -> dict:
+    normalized = _normalize_debug_action_payload(action)
+    if isinstance(normalized, dict):
+        action = normalized
     action_type = str(action.get("type", "")).strip()
     if not action_type:
         return {"type": "unknown", "ok": False, "error": "missing action type"}

--- a/app.py
+++ b/app.py
@@ -7721,6 +7721,16 @@ def api_debug_undo():
     audit_summary = "已回滾 Debug 修正（還原至套用前）"
     return jsonify({"ok": True, "restored": True, "audit_summary": audit_summary})
 
+
+@app.route("/api/debug/directive/clear", methods=["POST"])
+def api_debug_directive_clear():
+    story_id = _active_story_id()
+    body = request.get_json(force=True)
+    branch_id = body.get("branch_id", "main")
+    
+    _clear_debug_directive(story_id, branch_id)
+    return jsonify({"ok": True})
+
 @app.route("/api/debug/clear", methods=["POST"])
 def api_debug_clear():
     story_id = _active_story_id()

--- a/app.py
+++ b/app.py
@@ -248,6 +248,9 @@ STATE_RAG_TOKEN_BUDGET = max(200, _parse_env_int("STATE_RAG_TOKEN_BUDGET", 2000)
 STATE_RAG_MAX_ITEMS = max(1, _parse_env_int("STATE_RAG_MAX_ITEMS", 30))
 STATE_RAG_NPC_LIMIT = max(1, _parse_env_int("STATE_RAG_NPC_LIMIT", 10))
 GM_PLAN_CHAR_LIMIT = max(120, _parse_env_int("GM_PLAN_CHAR_LIMIT", 500))
+DEBUG_CHAT_CONTEXT_COUNT = max(1, _parse_env_int("DEBUG_CHAT_CONTEXT_COUNT", 20))
+DEBUG_CHAT_MAX_USER_CHARS = max(200, _parse_env_int("DEBUG_CHAT_MAX_USER_CHARS", 4000))
+DEBUG_APPLY_MAX_ACTIONS = max(1, _parse_env_int("DEBUG_APPLY_MAX_ACTIONS", 20))
 
 # Track in-flight async tag extraction jobs keyed by (story, branch, msg_index).
 _PENDING_EXTRACT_LOCK = threading.Lock()
@@ -421,6 +424,34 @@ def _branch_dir(story_id: str, branch_id: str) -> str:
     return d
 
 
+def _debug_units_dir(story_id: str) -> str:
+    d = os.path.join(_story_dir(story_id), "debug_units")
+    os.makedirs(d, exist_ok=True)
+    return d
+
+
+def _debug_unit_dir(story_id: str, debug_unit_id: str) -> str:
+    d = os.path.join(_debug_units_dir(story_id), debug_unit_id)
+    os.makedirs(d, exist_ok=True)
+    return d
+
+
+def _debug_chat_path(story_id: str, debug_unit_id: str) -> str:
+    return os.path.join(_debug_unit_dir(story_id, debug_unit_id), "chat.json")
+
+
+def _last_apply_backup_path(story_id: str, debug_unit_id: str) -> str:
+    return os.path.join(_debug_unit_dir(story_id, debug_unit_id), "last_apply_backup.json")
+
+
+def _debug_directive_path(story_id: str, branch_id: str) -> str:
+    return os.path.join(_branch_dir(story_id, branch_id), "debug_directive.json")
+
+
+def _dungeon_progress_path(story_id: str, branch_id: str) -> str:
+    return os.path.join(_branch_dir(story_id, branch_id), "dungeon_progress.json")
+
+
 def _story_messages_path(story_id: str, branch_id: str) -> str:
     return os.path.join(_branch_dir(story_id, branch_id), "messages.json")
 
@@ -508,6 +539,143 @@ def _load_tree(story_id: str) -> dict:
 
 def _save_tree(story_id: str, tree: dict):
     _save_json(_story_tree_path(story_id), tree)
+
+
+def _resolve_debug_unit_id(story_id: str, branch_id: str) -> str:
+    """Resolve debug-unit id from branch ancestry.
+
+    Walk parent_branch_id upward and use the top-most blank ancestor as unit id.
+    If no blank ancestor exists, fallback to current branch_id.
+    """
+    tree = _load_tree(story_id)
+    branches = tree.get("branches", {})
+    if branch_id not in branches:
+        return branch_id
+
+    cur = branch_id
+    visited = set()
+    top_blank_id: str | None = None
+    while cur is not None and cur not in visited:
+        visited.add(cur)
+        b = branches.get(cur)
+        if not b:
+            break
+        if b.get("blank"):
+            top_blank_id = b.get("id") or cur
+        cur = b.get("parent_branch_id")
+
+    return top_blank_id or branch_id
+
+
+def _load_debug_chat(story_id: str, debug_unit_id: str) -> list[dict]:
+    data = _load_json(_debug_chat_path(story_id, debug_unit_id), [])
+    if not isinstance(data, list):
+        return []
+    cleaned: list[dict] = []
+    for m in data:
+        if not isinstance(m, dict):
+            continue
+        role = m.get("role")
+        if role not in {"user", "assistant"}:
+            continue
+        content = str(m.get("content", "")).strip()
+        if not content:
+            continue
+        cleaned.append({
+            "role": role,
+            "content": content,
+            "created_at": m.get("created_at"),
+        })
+    return cleaned
+
+
+def _save_debug_chat(story_id: str, debug_unit_id: str, messages: list[dict]):
+    _save_json(_debug_chat_path(story_id, debug_unit_id), messages)
+
+
+def _append_debug_chat_message(story_id: str, debug_unit_id: str, role: str, content: str):
+    if role not in {"user", "assistant"}:
+        return
+    text = str(content or "").strip()
+    if not text:
+        return
+    chat = _load_debug_chat(story_id, debug_unit_id)
+    chat.append({
+        "role": role,
+        "content": text,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+    })
+    _save_debug_chat(story_id, debug_unit_id, chat)
+
+
+def _load_last_apply_backup(story_id: str, debug_unit_id: str) -> dict:
+    data = _load_json(_last_apply_backup_path(story_id, debug_unit_id), {})
+    return data if isinstance(data, dict) else {}
+
+
+def _save_last_apply_backup(story_id: str, debug_unit_id: str, backup: dict):
+    _save_json(_last_apply_backup_path(story_id, debug_unit_id), backup)
+
+
+def _clear_last_apply_backup(story_id: str, debug_unit_id: str):
+    path = _last_apply_backup_path(story_id, debug_unit_id)
+    if os.path.exists(path):
+        os.remove(path)
+
+
+def _load_debug_directive(story_id: str, branch_id: str) -> dict:
+    data = _load_json(_debug_directive_path(story_id, branch_id), {})
+    if not isinstance(data, dict):
+        return {}
+    instruction = str(data.get("instruction", "")).strip()
+    if not instruction:
+        return {}
+    result = dict(data)
+    result["instruction"] = instruction
+    return result
+
+
+def _save_debug_directive(story_id: str, branch_id: str, directive: dict):
+    if not isinstance(directive, dict):
+        return
+    instruction = str(directive.get("instruction", "")).strip()
+    if not instruction:
+        _clear_debug_directive(story_id, branch_id)
+        return
+    payload = dict(directive)
+    payload["instruction"] = instruction
+    if not payload.get("created_at"):
+        payload["created_at"] = datetime.now(timezone.utc).isoformat()
+    _save_json(_debug_directive_path(story_id, branch_id), payload)
+
+
+def _clear_debug_directive(story_id: str, branch_id: str):
+    path = _debug_directive_path(story_id, branch_id)
+    if os.path.exists(path):
+        os.remove(path)
+
+
+def _copy_debug_directive(story_id: str, from_bid: str, to_bid: str):
+    directive = _load_debug_directive(story_id, from_bid)
+    if directive:
+        _save_debug_directive(story_id, to_bid, directive)
+    else:
+        _clear_debug_directive(story_id, to_bid)
+
+
+def _append_debug_audit_message(story_id: str, branch_id: str, content: str) -> dict:
+    text = str(content or "").strip()
+    if not text:
+        text = "Debug 修正流程已執行。"
+    msg = {
+        "role": "system",
+        "message_type": "debug_audit",
+        "content": text,
+        "index": len(get_full_timeline(story_id, branch_id)),
+        "created_at": datetime.now(timezone.utc).isoformat(),
+    }
+    _upsert_branch_message(story_id, branch_id, msg)
+    return msg
 
 
 def _clear_loaded_save_preview(tree: dict) -> bool:
@@ -1187,6 +1355,8 @@ _LORE_RE = re.compile(_TAG_OPEN + r"LORE\s*(.*?)\s*LORE" + _TAG_CLOSE, re.DOTALL
 _NPC_RE = re.compile(_TAG_OPEN + r"NPC\s*(.*?)\s*NPC" + _TAG_CLOSE, re.DOTALL)
 _EVENT_RE = re.compile(_TAG_OPEN + r"EVENT\s*(.*?)\s*EVENT" + _TAG_CLOSE, re.DOTALL)
 _IMG_RE = re.compile(_TAG_OPEN + r"IMG\s+prompt:\s*(.*?)\s*IMG" + _TAG_CLOSE, re.DOTALL)
+_DEBUG_ACTION_RE = re.compile(r"<!--DEBUG_ACTION\s*(.*?)\s*DEBUG_ACTION-->", re.DOTALL)
+_DEBUG_DIRECTIVE_RE = re.compile(r"<!--DEBUG_DIRECTIVE\s*(.*?)\s*DEBUG_DIRECTIVE-->", re.DOTALL)
 
 
 def _extract_state_tag(text: str) -> tuple[str, list[dict]]:
@@ -1266,6 +1436,44 @@ def _extract_img_tag(text: str) -> tuple[str, str | None]:
         text = text[: m.start()].rstrip() + text[m.end():]
         text = text.strip()
     return text, first_prompt
+
+
+def _extract_debug_action_tags(text: str) -> tuple[str, list[dict]]:
+    """Extract all <!--DEBUG_ACTION {...} DEBUG_ACTION--> tags from debug response."""
+    actions: list[dict] = []
+    while True:
+        m = _DEBUG_ACTION_RE.search(text)
+        if not m:
+            break
+        try:
+            payload = json.loads(m.group(1))
+            if isinstance(payload, dict):
+                actions.append(payload)
+        except (json.JSONDecodeError, ValueError):
+            pass
+        text = text[: m.start()].rstrip() + text[m.end():]
+        text = text.strip()
+    return text, actions
+
+
+def _extract_debug_directive_tags(text: str) -> tuple[str, list[dict]]:
+    """Extract all <!--DEBUG_DIRECTIVE {...} DEBUG_DIRECTIVE--> tags from debug response."""
+    directives: list[dict] = []
+    while True:
+        m = _DEBUG_DIRECTIVE_RE.search(text)
+        if not m:
+            break
+        try:
+            payload = json.loads(m.group(1))
+            if isinstance(payload, dict):
+                instruction = str(payload.get("instruction", "")).strip()
+                if instruction:
+                    directives.append({"instruction": instruction})
+        except (json.JSONDecodeError, ValueError):
+            pass
+        text = text[: m.start()].rstrip() + text[m.end():]
+        text = text.strip()
+    return text, directives
 
 
 # ---------------------------------------------------------------------------
@@ -1844,6 +2052,66 @@ def _build_gm_plan_injection_block(story_id: str, branch_id: str, current_index:
             arc = arc[: max(16, len(arc) - 12)].rstrip() + "…"
             continue
         return block[:char_limit].rstrip()
+
+
+def _build_debug_directive_injection_block(story_id: str, branch_id: str) -> str:
+    directive = _load_debug_directive(story_id, branch_id)
+    instruction = str(directive.get("instruction", "")).strip()
+    if not instruction:
+        return ""
+    return "\n".join([
+        "[Debug 修正指令（僅供 GM 內部參考，勿透露給玩家）]",
+        instruction,
+    ])
+
+
+def _format_debug_recent_messages(messages: list[dict]) -> str:
+    if not messages:
+        return "（無）"
+    lines: list[str] = []
+    for m in messages:
+        role = m.get("role")
+        if role == "user":
+            label = "玩家"
+        elif role in {"gm", "assistant"}:
+            label = "GM"
+        else:
+            label = "系統"
+        idx = m.get("index")
+        content = str(m.get("content", "")).strip()
+        if len(content) > 320:
+            content = content[:320].rstrip() + "…"
+        lines.append(f"[#{idx}][{label}] {content}")
+    return "\n".join(lines)
+
+
+def _build_debug_system_prompt(story_id: str, branch_id: str, recent_messages: list[dict]) -> str:
+    state = _load_character_state(story_id, branch_id)
+    npcs = _load_npcs(story_id, branch_id, include_archived=True)
+    world_day = get_world_day(story_id, branch_id)
+    dungeon_progress = _load_dungeon_progress(story_id, branch_id) or {}
+    gm_plan = _load_gm_plan(story_id, branch_id)
+    pending_directive = _load_debug_directive(story_id, branch_id)
+    recent_text = _format_debug_recent_messages(recent_messages)
+
+    return (
+        "你是 RPG Debug 診斷與修正助手。你的任務是：\n"
+        "1. 協助檢查狀態/NPC/獎勵點/世界日/副本進度是否一致。\n"
+        "2. 可以提供修正提案，但不做劇情演出。\n"
+        "3. 修正提案請用標籤輸出：<!--DEBUG_ACTION {json} DEBUG_ACTION-->。\n"
+        "4. 劇情修正指令請用標籤輸出：<!--DEBUG_DIRECTIVE {\"instruction\":\"...\"} DEBUG_DIRECTIVE-->。\n"
+        "5. 標籤以外的文字會顯示給使用者，請清楚說明判斷依據。\n"
+        "6. 若資訊不足，先追問，不要硬猜。\n\n"
+        "可用 action type：state_patch / npc_upsert / npc_delete / world_day_set / dungeon_patch。\n"
+        "dungeon_patch 可用欄位：progress_delta、completed_nodes、discovered_areas、explored_area_updates。\n\n"
+        f"[主聊天最近訊息（唯讀參考）]\n{recent_text}\n\n"
+        f"[character_state.json]\n{json.dumps(state, ensure_ascii=False, indent=2)}\n\n"
+        f"[npcs.json（含 archived）]\n{json.dumps(npcs, ensure_ascii=False, indent=2)}\n\n"
+        f"[world_day]\n{json.dumps(world_day, ensure_ascii=False)}\n\n"
+        f"[dungeon_progress.json]\n{json.dumps(dungeon_progress, ensure_ascii=False, indent=2)}\n\n"
+        f"[gm_plan.json]\n{json.dumps(gm_plan, ensure_ascii=False, indent=2)}\n\n"
+        f"[pending_debug_directive]\n{json.dumps(pending_directive, ensure_ascii=False, indent=2)}\n"
+    )
 
 
 def _search_branch_lore(story_id: str, branch_id: str, query: str,
@@ -3976,7 +4244,7 @@ def _migrate_design_files(story_id: str):
 # ---------------------------------------------------------------------------
 
 _CONTEXT_ECHO_RE = re.compile(
-    r"\[(?:命運走向|命運判定|命運骰結果|相關世界設定|相關事件追蹤|NPC 近期動態|GM 敘事計劃（僅供 GM 內部參考，勿透露給玩家）)\].*?(?=\n---\n|\n\n[^\[\n]|\Z)",
+    r"\[(?:命運走向|命運判定|命運骰結果|相關世界設定|相關事件追蹤|NPC 近期動態|GM 敘事計劃（僅供 GM 內部參考，勿透露給玩家）|Debug 修正指令（僅供 GM 內部參考，勿透露給玩家）)\].*?(?=\n---\n|\n\n[^\[\n]|\Z)",
     re.DOTALL,
 )
 
@@ -4037,7 +4305,8 @@ def _strip_choices_from_messages(messages: list[dict]) -> list[dict]:
 
 def _sanitize_recent_messages(messages: list[dict], *, strip_fate: bool) -> list[dict]:
     """Strip non-narrative scaffolding from recent messages before model input."""
-    cleaned = _strip_choices_from_messages(messages)
+    cleaned = [m for m in messages if m.get("message_type") != "debug_audit"]
+    cleaned = _strip_choices_from_messages(cleaned)
     if strip_fate:
         cleaned = _strip_fate_from_messages(cleaned)
     return cleaned
@@ -4112,6 +4381,9 @@ def _process_gm_response(gm_response: str, story_id: str, branch_id: str, msg_in
         "world_day_snapshot": get_world_day(story_id, branch_id),
         "dungeon_progress_snapshot": get_dungeon_progress_snapshot(story_id, branch_id),
     }
+
+    # One-shot consume: clear debug directive after one GM turn is produced.
+    _clear_debug_directive(story_id, branch_id)
 
     return gm_response, image_info, snapshots
 
@@ -4240,6 +4512,9 @@ def _build_augmented_message(
             plan_block = _build_gm_plan_injection_block(story_id, branch_id, current_index)
             if plan_block:
                 parts.append(plan_block)
+    directive_block = _build_debug_directive_injection_block(story_id, branch_id)
+    if directive_block:
+        parts.append(directive_block)
     activities = get_recent_activities(story_id, branch_id, limit=2)
     if activities:
         parts.append(activities)
@@ -4890,6 +5165,7 @@ def api_branches_create():
     copy_events_for_fork(story_id, source_branch_id, branch_id, branch_point_index)
     _copy_gm_plan(story_id, source_branch_id, branch_id, branch_point_index=branch_point_index)
     copy_dungeon_progress(story_id, parent_branch_id, branch_id)
+    _copy_debug_directive(story_id, source_branch_id, branch_id)
 
     _save_branch_messages(story_id, branch_id, [])
 
@@ -5110,6 +5386,7 @@ def api_branches_edit():
     copy_events_for_fork(story_id, source_branch_id, branch_id, branch_point_index)
     _copy_gm_plan(story_id, source_branch_id, branch_id, branch_point_index=branch_point_index)
     copy_dungeon_progress(story_id, parent_branch_id, branch_id)
+    _copy_debug_directive(story_id, source_branch_id, branch_id)
 
     user_msg_index = branch_point_index + 1
     gm_msg_index = branch_point_index + 2
@@ -5288,6 +5565,7 @@ def api_branches_edit_stream():
     copy_events_for_fork(story_id, source_branch_id, branch_id, branch_point_index)
     _copy_gm_plan(story_id, source_branch_id, branch_id, branch_point_index=branch_point_index)
     copy_dungeon_progress(story_id, parent_branch_id, branch_id)
+    _copy_debug_directive(story_id, source_branch_id, branch_id)
 
     user_msg_index = branch_point_index + 1
     gm_msg_index = branch_point_index + 2
@@ -5473,6 +5751,7 @@ def api_branches_regenerate():
     copy_events_for_fork(story_id, source_branch_id, branch_id, branch_point_index)
     _copy_gm_plan(story_id, source_branch_id, branch_id, branch_point_index=branch_point_index)
     copy_dungeon_progress(story_id, parent_branch_id, branch_id)
+    _copy_debug_directive(story_id, source_branch_id, branch_id)
 
     _save_branch_messages(story_id, branch_id, [])
 
@@ -5857,6 +6136,7 @@ def api_branches_promote():
     parent_id = branches[branch_id].get("parent_branch_id")
     if isinstance(parent_id, str) and parent_id in branches:
         _copy_gm_plan(story_id, branch_id, parent_id, branch_point_index=None)
+        _copy_debug_directive(story_id, branch_id, parent_id)
 
     tree["active_branch_id"] = branch_id
     tree["promoted_mainline_leaf_id"] = branch_id
@@ -6797,6 +7077,366 @@ def api_lore_apply():
                 delete_lore_entry(story_id, topic, sub)
                 applied.append({"action": "delete", "topic": topic})
     return jsonify({"ok": True, "applied": applied})
+
+
+# ---------------------------------------------------------------------------
+# Debug Panel API
+# ---------------------------------------------------------------------------
+
+def _pick_latest_debug_directive(directives: object) -> dict | None:
+    if not isinstance(directives, list):
+        return None
+    latest: dict | None = None
+    for item in directives:
+        if not isinstance(item, dict):
+            continue
+        instruction = str(item.get("instruction", "")).strip()
+        if not instruction:
+            continue
+        latest = {"instruction": instruction}
+    return latest
+
+
+def _apply_debug_action(story_id: str, branch_id: str, action: dict) -> dict:
+    action_type = str(action.get("type", "")).strip()
+    if not action_type:
+        return {"type": "unknown", "ok": False, "error": "missing action type"}
+
+    if action_type == "state_patch":
+        update = action.get("update")
+        if not isinstance(update, dict):
+            return {"type": action_type, "ok": False, "error": "invalid state update"}
+        _apply_state_update(story_id, branch_id, update)
+        return {"type": action_type, "ok": True}
+
+    if action_type == "npc_upsert":
+        npc = action.get("npc")
+        if not isinstance(npc, dict) or not str(npc.get("name", "")).strip():
+            return {"type": action_type, "ok": False, "error": "invalid npc payload"}
+        _save_npc(story_id, npc, branch_id)
+        return {"type": action_type, "ok": True}
+
+    if action_type == "npc_delete":
+        npc_id = str(action.get("npc_id", "")).strip()
+        if not npc_id:
+            return {"type": action_type, "ok": False, "error": "npc_id required"}
+        npcs = _load_npcs(story_id, branch_id, include_archived=True)
+        removed_names = [n.get("name", "").strip() for n in npcs if n.get("id") == npc_id and n.get("name")]
+        if not removed_names:
+            return {"type": action_type, "ok": False, "error": "npc not found"}
+        npcs = [n for n in npcs if n.get("id") != npc_id]
+        _save_json(_story_npcs_path(story_id, branch_id), npcs)
+        for name in removed_names:
+            delete_state_entry(story_id, branch_id, category="npc", entry_key=name)
+        return {"type": action_type, "ok": True}
+
+    if action_type == "world_day_set":
+        world_day = action.get("world_day")
+        try:
+            day_value = float(world_day)
+        except (TypeError, ValueError):
+            return {"type": action_type, "ok": False, "error": "invalid world_day"}
+        if day_value < 0:
+            return {"type": action_type, "ok": False, "error": "world_day must be >= 0"}
+        set_world_day(story_id, branch_id, day_value)
+        return {"type": action_type, "ok": True}
+
+    if action_type == "dungeon_patch":
+        progress = _load_dungeon_progress(story_id, branch_id)
+        if not progress or not progress.get("current_dungeon"):
+            return {"type": action_type, "ok": False, "error": "no active dungeon"}
+
+        progress_delta_raw = action.get("progress_delta", action.get("mainline_progress_delta"))
+        completed_nodes = action.get("completed_nodes", [])
+        discovered_areas = action.get("discovered_areas", [])
+        explored_updates = action.get("explored_area_updates", {})
+        did_update = False
+
+        if progress_delta_raw is not None or completed_nodes:
+            if progress_delta_raw is None:
+                progress_delta = 0
+            else:
+                try:
+                    progress_delta = int(float(progress_delta_raw))
+                except (TypeError, ValueError):
+                    return {"type": action_type, "ok": False, "error": "invalid progress_delta"}
+            if not isinstance(completed_nodes, list):
+                return {"type": action_type, "ok": False, "error": "completed_nodes must be a list"}
+            update_dungeon_progress(story_id, branch_id, {
+                "progress_delta": progress_delta,
+                "nodes_completed": [str(x) for x in completed_nodes if str(x).strip()],
+            })
+            did_update = True
+
+        if discovered_areas or explored_updates:
+            if not isinstance(discovered_areas, list):
+                return {"type": action_type, "ok": False, "error": "discovered_areas must be a list"}
+            if not isinstance(explored_updates, dict):
+                return {"type": action_type, "ok": False, "error": "explored_area_updates must be an object"}
+            cleaned_updates = {}
+            for area_id, delta in explored_updates.items():
+                try:
+                    cleaned_updates[str(area_id)] = int(float(delta))
+                except (TypeError, ValueError):
+                    continue
+            update_dungeon_area(story_id, branch_id, {
+                "discovered_areas": [str(x) for x in discovered_areas if str(x).strip()],
+                "explored_area_updates": cleaned_updates,
+            })
+            did_update = True
+
+        if not did_update:
+            return {"type": action_type, "ok": False, "error": "empty dungeon patch"}
+        return {"type": action_type, "ok": True}
+
+    return {"type": action_type, "ok": False, "error": f"unsupported action type: {action_type}"}
+
+
+def _build_debug_apply_audit_summary(results: list[dict], directive_applied: int) -> str:
+    total = len(results)
+    success = sum(1 for r in results if r.get("ok"))
+    failed_types = [str(r.get("type", "unknown")) for r in results if not r.get("ok")]
+    if total == 0:
+        summary = "未套用資料修正"
+    elif success == 0:
+        summary = f"所有修正項目失敗（0/{total}）"
+    elif success == total:
+        summary = f"已套用 {success}/{total} 項修正"
+    else:
+        summary = f"已套用 {success}/{total} 項修正（{total - success} 項失敗：{', '.join(failed_types[:5])}）"
+
+    if directive_applied > 0:
+        summary += "；已注入劇情指令"
+    return summary
+
+
+@app.route("/api/debug/session")
+def api_debug_session():
+    story_id = _active_story_id()
+    branch_id = request.args.get("branch_id", "main")
+    tree = _load_tree(story_id)
+    if branch_id not in tree.get("branches", {}):
+        return jsonify({"ok": False, "error": "branch not found"}), 404
+
+    debug_unit_id = _resolve_debug_unit_id(story_id, branch_id)
+    messages = _load_debug_chat(story_id, debug_unit_id)
+    return jsonify({
+        "ok": True,
+        "debug_unit_id": debug_unit_id,
+        "target_branch_id": branch_id,
+        "messages": messages,
+        "state_snapshot": _load_character_state(story_id, branch_id),
+        "npcs_snapshot": _load_npcs(story_id, branch_id, include_archived=True),
+        "world_day": get_world_day(story_id, branch_id),
+        "dungeon_progress": _load_dungeon_progress(story_id, branch_id) or {},
+        "gm_plan": _load_gm_plan(story_id, branch_id),
+        "pending_directive": _load_debug_directive(story_id, branch_id),
+    })
+
+
+@app.route("/api/debug/chat/stream", methods=["POST"])
+def api_debug_chat_stream():
+    story_id = _active_story_id()
+    body = request.get_json(force=True)
+    branch_id = body.get("branch_id", "main")
+    user_message = str(body.get("user_message", "")).strip()
+    if not user_message:
+        return Response(_sse_event({"type": "error", "message": "user_message required"}),
+                        mimetype="text/event-stream")
+    if len(user_message) > DEBUG_CHAT_MAX_USER_CHARS:
+        return Response(_sse_event({"type": "error", "message": f"user_message too long (>{DEBUG_CHAT_MAX_USER_CHARS})"}),
+                        mimetype="text/event-stream")
+
+    tree = _load_tree(story_id)
+    if branch_id not in tree.get("branches", {}):
+        return Response(_sse_event({"type": "error", "message": "branch not found"}),
+                        mimetype="text/event-stream")
+
+    debug_unit_id = _resolve_debug_unit_id(story_id, branch_id)
+    existing_chat = _load_debug_chat(story_id, debug_unit_id)
+    prior = [{"role": m["role"], "content": m["content"]} for m in existing_chat[-DEBUG_CHAT_CONTEXT_COUNT:]]
+    _append_debug_chat_message(story_id, debug_unit_id, "user", user_message)
+
+    full_timeline = get_full_timeline(story_id, branch_id)
+    recent = _sanitize_recent_messages(
+        full_timeline[-RECENT_MESSAGE_COUNT:],
+        strip_fate=not get_fate_mode(_story_dir(story_id), branch_id),
+    )
+    debug_system_prompt = _build_debug_system_prompt(story_id, branch_id, recent)
+
+    _trace_llm(
+        stage="debug_chat_request",
+        story_id=story_id,
+        branch_id=branch_id,
+        source="/api/debug/chat/stream",
+        payload={
+            "debug_unit_id": debug_unit_id,
+            "user_message": user_message,
+            "system_prompt": debug_system_prompt,
+            "recent_debug_messages": prior,
+        },
+        tags={"mode": "stream"},
+    )
+
+    def generate():
+        t_start = time.time()
+        try:
+            for event_type, payload in call_claude_gm_stream(
+                user_message, debug_system_prompt, prior, session_id=None
+            ):
+                if event_type == "text":
+                    yield _sse_event({"type": "text", "chunk": payload})
+                elif event_type == "error":
+                    yield _sse_event({"type": "error", "message": payload})
+                    return
+                elif event_type == "done":
+                    response_raw = payload.get("response", "")
+                    _log_llm_usage(story_id, "debug_chat", time.time() - t_start,
+                                   branch_id=branch_id, usage=payload.get("usage"))
+                    _trace_llm(
+                        stage="debug_chat_response_raw",
+                        story_id=story_id,
+                        branch_id=branch_id,
+                        source="/api/debug/chat/stream",
+                        payload={"response": response_raw, "usage": payload.get("usage")},
+                        tags={"mode": "stream"},
+                    )
+
+                    display_text, proposals = _extract_debug_action_tags(response_raw)
+                    display_text, directives = _extract_debug_directive_tags(display_text)
+                    display_text = display_text.strip()
+                    if display_text:
+                        _append_debug_chat_message(story_id, debug_unit_id, "assistant", display_text)
+                    done_payload = {
+                        "type": "done",
+                        "response": display_text,
+                        "proposals": proposals,
+                        "directives": directives,
+                    }
+                    yield _sse_event(done_payload)
+        except Exception as e:
+            log.info("/api/debug/chat/stream EXCEPTION %s", e)
+            yield _sse_event({"type": "error", "message": str(e)})
+
+    return Response(stream_with_context(generate()), mimetype="text/event-stream")
+
+
+@app.route("/api/debug/apply", methods=["POST"])
+def api_debug_apply():
+    story_id = _active_story_id()
+    body = request.get_json(force=True)
+    branch_id = body.get("branch_id", "main")
+    actions = body.get("actions", [])
+    directives = body.get("directives", [])
+
+    tree = _load_tree(story_id)
+    if branch_id not in tree.get("branches", {}):
+        return jsonify({"ok": False, "error": "branch not found"}), 404
+    if not isinstance(actions, list):
+        return jsonify({"ok": False, "error": "actions must be a list"}), 400
+    if not isinstance(directives, list):
+        return jsonify({"ok": False, "error": "directives must be a list"}), 400
+    if len(actions) > DEBUG_APPLY_MAX_ACTIONS:
+        return jsonify({"ok": False, "error": f"too many actions (max {DEBUG_APPLY_MAX_ACTIONS})"}), 400
+
+    debug_unit_id = _resolve_debug_unit_id(story_id, branch_id)
+    backup = {
+        "version": 1,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "debug_unit_id": debug_unit_id,
+        "target_branch_id": branch_id,
+        "state_snapshot": _load_character_state(story_id, branch_id),
+        "npcs_snapshot": _load_npcs(story_id, branch_id, include_archived=True),
+        "world_day": get_world_day(story_id, branch_id),
+        "dungeon_progress_snapshot": _load_dungeon_progress(story_id, branch_id) or {
+            "history": [],
+            "current_dungeon": None,
+            "total_dungeons_completed": 0,
+        },
+    }
+    _save_last_apply_backup(story_id, debug_unit_id, backup)
+
+    results: list[dict] = []
+    for raw_action in actions:
+        if not isinstance(raw_action, dict):
+            results.append({"type": "unknown", "ok": False, "error": "invalid action payload"})
+            continue
+        try:
+            results.append(_apply_debug_action(story_id, branch_id, raw_action))
+        except Exception as e:
+            action_type = str(raw_action.get("type", "unknown"))
+            results.append({"type": action_type, "ok": False, "error": str(e)})
+
+    directive_result = {"ok": True, "applied": 0}
+    latest_directive = _pick_latest_debug_directive(directives)
+    if latest_directive:
+        try:
+            _save_debug_directive(story_id, branch_id, {
+                **latest_directive,
+                "created_at": datetime.now(timezone.utc).isoformat(),
+                "source": "debug_apply",
+                "debug_unit_id": debug_unit_id,
+            })
+            directive_result["applied"] = 1
+        except Exception as e:
+            directive_result = {"ok": False, "applied": 0, "error": str(e)}
+
+    audit_summary = _build_debug_apply_audit_summary(results, directive_result.get("applied", 0))
+    _append_debug_audit_message(story_id, branch_id, audit_summary)
+
+    return jsonify({
+        "ok": True,
+        "results": results,
+        "directive_result": directive_result,
+        "audit_summary": audit_summary,
+    })
+
+
+@app.route("/api/debug/undo", methods=["POST"])
+def api_debug_undo():
+    story_id = _active_story_id()
+    body = request.get_json(force=True)
+    branch_id = body.get("branch_id", "main")
+
+    tree = _load_tree(story_id)
+    if branch_id not in tree.get("branches", {}):
+        return jsonify({"ok": False, "error": "branch not found"}), 404
+
+    debug_unit_id = _resolve_debug_unit_id(story_id, branch_id)
+    backup = _load_last_apply_backup(story_id, debug_unit_id)
+    if not backup:
+        return jsonify({"ok": False, "error": "no backup available"}), 400
+    if backup.get("target_branch_id") != branch_id:
+        return jsonify({"ok": False, "error": "backup target mismatch"}), 400
+
+    state_snapshot = backup.get("state_snapshot")
+    npcs_snapshot = backup.get("npcs_snapshot")
+    world_day = backup.get("world_day")
+    dungeon_snapshot = backup.get("dungeon_progress_snapshot")
+
+    if not isinstance(state_snapshot, dict):
+        return jsonify({"ok": False, "error": "backup state invalid"}), 400
+    if not isinstance(npcs_snapshot, list):
+        return jsonify({"ok": False, "error": "backup npc snapshot invalid"}), 400
+    if not isinstance(dungeon_snapshot, dict):
+        return jsonify({"ok": False, "error": "backup dungeon snapshot invalid"}), 400
+
+    _save_json(_story_character_state_path(story_id, branch_id), state_snapshot)
+    _save_json(_story_npcs_path(story_id, branch_id), npcs_snapshot)
+    rebuild_state_db_from_json(story_id, branch_id, state=state_snapshot, npcs=npcs_snapshot)
+
+    try:
+        set_world_day(story_id, branch_id, float(world_day))
+    except (TypeError, ValueError):
+        set_world_day(story_id, branch_id, get_world_day(story_id, branch_id))
+
+    _save_json(_dungeon_progress_path(story_id, branch_id), dungeon_snapshot)
+    _clear_debug_directive(story_id, branch_id)
+    _clear_last_apply_backup(story_id, debug_unit_id)
+
+    audit_summary = "已回滾 Debug 修正（還原至套用前）"
+    _append_debug_audit_message(story_id, branch_id, audit_summary)
+    return jsonify({"ok": True, "restored": True, "audit_summary": audit_summary})
 
 
 # ---------------------------------------------------------------------------

--- a/app.py
+++ b/app.py
@@ -5165,8 +5165,6 @@ def api_branches_create():
     copy_events_for_fork(story_id, source_branch_id, branch_id, branch_point_index)
     _copy_gm_plan(story_id, source_branch_id, branch_id, branch_point_index=branch_point_index)
     copy_dungeon_progress(story_id, parent_branch_id, branch_id)
-    _copy_debug_directive(story_id, source_branch_id, branch_id)
-
     _save_branch_messages(story_id, branch_id, [])
 
     branches[branch_id] = {

--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ import copy
 import json
 import logging
 import logging.handlers
+import math
 import os
 import re
 import shutil
@@ -251,6 +252,7 @@ GM_PLAN_CHAR_LIMIT = max(120, _parse_env_int("GM_PLAN_CHAR_LIMIT", 500))
 DEBUG_CHAT_CONTEXT_COUNT = max(1, _parse_env_int("DEBUG_CHAT_CONTEXT_COUNT", 20))
 DEBUG_CHAT_MAX_USER_CHARS = max(200, _parse_env_int("DEBUG_CHAT_MAX_USER_CHARS", 4000))
 DEBUG_APPLY_MAX_ACTIONS = max(1, _parse_env_int("DEBUG_APPLY_MAX_ACTIONS", 20))
+DEBUG_APPLY_MAX_DIRECTIVES = max(1, _parse_env_int("DEBUG_APPLY_MAX_DIRECTIVES", 20))
 
 # Track in-flight async tag extraction jobs keyed by (story, branch, msg_index).
 _PENDING_EXTRACT_LOCK = threading.Lock()
@@ -2246,6 +2248,8 @@ def _build_debug_system_prompt(story_id: str, branch_id: str, recent_messages: l
     pending_directive = _load_debug_directive(story_id, branch_id)
     recent_text = _format_debug_recent_messages(recent_messages)
 
+    # V1 intentionally injects full JSON snapshots. Large stories can exceed
+    # model context here because this prompt path does not enforce a token budget.
     return (
         "你是 RPG Debug 診斷與修正助手。你的任務是：\n"
         "1. 協助檢查狀態/NPC/獎勵點/世界日/副本進度是否一致。\n"
@@ -3987,17 +3991,61 @@ def _next_timeline_index(story_id: str, branch_id: str, timeline: list[dict] | N
     """Return the next message index for appending in a branch timeline."""
     if timeline is None:
         timeline = get_full_timeline(story_id, branch_id)
-    max_index = -1
-    for msg in timeline:
-        idx = msg.get("index")
-        if isinstance(idx, str):
-            try:
-                idx = int(idx)
-            except ValueError:
-                continue
-        if isinstance(idx, int):
-            if idx > max_index:
-                max_index = idx
+    max_index = _max_message_index(timeline)
+    if max_index is None:
+        return 0
+    return max_index + 1
+
+
+def _coerce_message_index(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _max_message_index(messages: object) -> int | None:
+    if not isinstance(messages, list):
+        return None
+    max_index: int | None = None
+    for msg in messages:
+        if not isinstance(msg, dict):
+            continue
+        idx = _coerce_message_index(msg.get("index"))
+        if idx is None:
+            continue
+        if max_index is None or idx > max_index:
+            max_index = idx
+    return max_index
+
+
+def _next_branch_message_index_fast(story_id: str, branch_id: str) -> int:
+    """Cheap next-index lookup for append-only debug audit messages."""
+    delta_max = _max_message_index(_load_branch_messages(story_id, branch_id))
+    tree = _load_tree(story_id)
+    branches = tree.get("branches", {})
+    branch = branches.get(branch_id, {})
+
+    if branch_id == "main" or branch.get("parent_branch_id") is None:
+        inherited_max = _max_message_index(_load_json(_story_parsed_path(story_id), []))
+    else:
+        branch_point_index = _coerce_message_index(branch.get("branch_point_index"))
+        if branch_point_index is not None:
+            inherited_max = branch_point_index
+        else:
+            inherited_max = _max_message_index(get_full_timeline(story_id, branch_id))
+
+    max_index = inherited_max
+    if delta_max is not None and (max_index is None or delta_max > max_index):
+        max_index = delta_max
+    if max_index is None:
+        return 0
     return max_index + 1
 
 
@@ -7368,15 +7416,14 @@ def api_lore_apply():
 def _pick_latest_debug_directive(directives: object) -> dict | None:
     if not isinstance(directives, list):
         return None
-    latest: dict | None = None
-    for item in directives:
+    for item in reversed(directives):
         if not isinstance(item, dict):
             continue
         instruction = str(item.get("instruction", "")).strip()
         if not instruction:
             continue
-        latest = {"instruction": instruction}
-    return latest
+        return {"instruction": instruction}
+    return None
 
 
 def _apply_debug_action(story_id: str, branch_id: str, action: dict) -> dict:
@@ -7493,6 +7540,19 @@ def _build_debug_apply_audit_summary(results: list[dict], directive_applied: int
     if directive_applied > 0:
         summary += "；已注入劇情指令"
     return summary
+
+
+def _append_debug_audit_message(story_id: str, branch_id: str, summary: str):
+    text = str(summary or "").strip()
+    if not text:
+        return
+    _upsert_branch_message(story_id, branch_id, {
+        "role": "system",
+        "message_type": "debug_audit",
+        "content": text,
+        "index": _next_branch_message_index_fast(story_id, branch_id),
+        "created_at": datetime.now(timezone.utc).isoformat(),
+    })
 
 
 @app.route("/api/debug/session")
@@ -7623,6 +7683,8 @@ def api_debug_apply():
         return jsonify({"ok": False, "error": "directives must be a list"}), 400
     if len(actions) > DEBUG_APPLY_MAX_ACTIONS:
         return jsonify({"ok": False, "error": f"too many actions (max {DEBUG_APPLY_MAX_ACTIONS})"}), 400
+    if len(directives) > DEBUG_APPLY_MAX_DIRECTIVES:
+        return jsonify({"ok": False, "error": f"too many directives (max {DEBUG_APPLY_MAX_DIRECTIVES})"}), 400
 
     debug_unit_id = _resolve_debug_unit_id(story_id, branch_id)
     backup = {
@@ -7667,6 +7729,10 @@ def api_debug_apply():
             directive_result = {"ok": False, "applied": 0, "error": str(e)}
 
     audit_summary = _build_debug_apply_audit_summary(results, directive_result.get("applied", 0))
+    try:
+        _append_debug_audit_message(story_id, branch_id, audit_summary)
+    except Exception as e:
+        log.warning("debug apply audit append failed: story=%s branch=%s error=%s", story_id, branch_id, e)
 
     return jsonify({
         "ok": True,
@@ -7704,21 +7770,35 @@ def api_debug_undo():
         return jsonify({"ok": False, "error": "backup npc snapshot invalid"}), 400
     if not isinstance(dungeon_snapshot, dict):
         return jsonify({"ok": False, "error": "backup dungeon snapshot invalid"}), 400
+    try:
+        restored_world_day = float(world_day)
+    except (TypeError, ValueError):
+        log.warning(
+            "debug undo rejected: invalid backup world_day story=%s branch=%s debug_unit=%s value=%r",
+            story_id, branch_id, debug_unit_id, world_day,
+        )
+        return jsonify({"ok": False, "error": "backup world_day invalid"}), 400
+    if not math.isfinite(restored_world_day) or restored_world_day < 0:
+        log.warning(
+            "debug undo rejected: non-finite backup world_day story=%s branch=%s debug_unit=%s value=%r",
+            story_id, branch_id, debug_unit_id, world_day,
+        )
+        return jsonify({"ok": False, "error": "backup world_day invalid"}), 400
 
     _save_json(_story_character_state_path(story_id, branch_id), state_snapshot)
     _save_json(_story_npcs_path(story_id, branch_id), npcs_snapshot)
     rebuild_state_db_from_json(story_id, branch_id, state=state_snapshot, npcs=npcs_snapshot)
-
-    try:
-        set_world_day(story_id, branch_id, float(world_day))
-    except (TypeError, ValueError):
-        set_world_day(story_id, branch_id, get_world_day(story_id, branch_id))
+    set_world_day(story_id, branch_id, restored_world_day)
 
     _save_json(_dungeon_progress_path(story_id, branch_id), dungeon_snapshot)
     _clear_debug_directive(story_id, branch_id)
     _clear_last_apply_backup(story_id, debug_unit_id)
 
     audit_summary = "已回滾 Debug 修正（還原至套用前）"
+    try:
+        _append_debug_audit_message(story_id, branch_id, audit_summary)
+    except Exception as e:
+        log.warning("debug undo audit append failed: story=%s branch=%s error=%s", story_id, branch_id, e)
     return jsonify({"ok": True, "restored": True, "audit_summary": audit_summary})
 
 

--- a/app.py
+++ b/app.py
@@ -663,21 +663,6 @@ def _copy_debug_directive(story_id: str, from_bid: str, to_bid: str):
         _clear_debug_directive(story_id, to_bid)
 
 
-def _append_debug_audit_message(story_id: str, branch_id: str, content: str) -> dict:
-    text = str(content or "").strip()
-    if not text:
-        text = "Debug 修正流程已執行。"
-    msg = {
-        "role": "system",
-        "message_type": "debug_audit",
-        "content": text,
-        "index": len(get_full_timeline(story_id, branch_id)),
-        "created_at": datetime.now(timezone.utc).isoformat(),
-    }
-    _upsert_branch_message(story_id, branch_id, msg)
-    return msg
-
-
 def _clear_loaded_save_preview(tree: dict) -> bool:
     """Clear loaded-save status preview metadata from timeline tree."""
     changed = False
@@ -7682,7 +7667,6 @@ def api_debug_apply():
             directive_result = {"ok": False, "applied": 0, "error": str(e)}
 
     audit_summary = _build_debug_apply_audit_summary(results, directive_result.get("applied", 0))
-    _append_debug_audit_message(story_id, branch_id, audit_summary)
 
     return jsonify({
         "ok": True,
@@ -7735,7 +7719,6 @@ def api_debug_undo():
     _clear_last_apply_backup(story_id, debug_unit_id)
 
     audit_summary = "已回滾 Debug 修正（還原至套用前）"
-    _append_debug_audit_message(story_id, branch_id, audit_summary)
     return jsonify({"ok": True, "restored": True, "audit_summary": audit_summary})
 
 @app.route("/api/debug/clear", methods=["POST"])

--- a/app.py
+++ b/app.py
@@ -7565,6 +7565,24 @@ def api_debug_undo():
     _append_debug_audit_message(story_id, branch_id, audit_summary)
     return jsonify({"ok": True, "restored": True, "audit_summary": audit_summary})
 
+@app.route("/api/debug/clear", methods=["POST"])
+def api_debug_clear():
+    story_id = _active_story_id()
+    body = request.get_json(force=True)
+    branch_id = body.get("branch_id", "main")
+
+    tree = _load_tree(story_id)
+    if branch_id not in tree.get("branches", {}):
+        return jsonify({"ok": False, "error": "branch not found"}), 404
+
+    debug_unit_id = _resolve_debug_unit_id(story_id, branch_id)
+    
+    # 清除 chat 與 pending
+    _save_json(_debug_chat_path(story_id, debug_unit_id), [])
+    _clear_debug_directive(story_id, branch_id)
+    _clear_last_apply_backup(story_id, debug_unit_id)
+
+    return jsonify({"ok": True, "audit_summary": "已清除 Debug 對話與提案紀錄"})
 
 # ---------------------------------------------------------------------------
 # NPC API

--- a/app.py
+++ b/app.py
@@ -1490,7 +1490,7 @@ def _normalize_debug_action_payload(payload: object) -> dict | None:
         if nested:
             return nested
 
-    action_type = str(data.get("type") or data.get("action_type") or data.get("kind") or "").strip()
+    action_type = str(data.get("type") or data.get("action_type") or data.get("kind") or data.get("action") or "").strip()
     if action_type in _DEBUG_ACTION_TYPES:
         normalized = dict(data)
         normalized["type"] = action_type
@@ -1501,13 +1501,19 @@ def _normalize_debug_action_payload(payload: object) -> dict | None:
 
         if action_type == "state_patch":
             state_obj = normalized.get("state_patch")
+            patch_obj = normalized.get("patch")
+            patch_data_obj = normalized.get("patch_data")
             if not isinstance(normalized.get("update"), dict):
                 if isinstance(state_obj, dict):
                     normalized["update"] = state_obj
+                elif isinstance(patch_obj, dict):
+                    normalized["update"] = patch_obj
+                elif isinstance(patch_data_obj, dict):
+                    normalized["update"] = patch_data_obj
                 else:
                     extras = {
                         k: v for k, v in normalized.items()
-                        if k not in {"type", "action_type", "kind", "payload", "state_patch"}
+                        if k not in {"type", "action_type", "kind", "action", "payload", "state_patch", "patch", "patch_data"}
                     }
                     if extras:
                         normalized["update"] = extras
@@ -1532,6 +1538,10 @@ def _normalize_debug_action_payload(payload: object) -> dict | None:
 
     if isinstance(data.get("update"), dict):
         return {"type": "state_patch", "update": data["update"]}
+    if isinstance(data.get("patch"), dict):
+        return {"type": "state_patch", "update": data["patch"]}
+    if isinstance(data.get("patch_data"), dict):
+        return {"type": "state_patch", "update": data["patch_data"]}
 
     if "world_day" in data:
         return {"type": "world_day_set", "world_day": data.get("world_day")}

--- a/compaction.py
+++ b/compaction.py
@@ -170,6 +170,8 @@ def _format_messages(messages: list[dict]) -> str:
     """Format messages for the compaction prompt."""
     lines = []
     for msg in messages:
+        if msg.get("message_type") == "debug_audit":
+            continue
         prefix = "【玩家】" if msg.get("role") == "user" else "【GM】"
         content = msg.get("content", "")
         if msg.get("role") != "user":

--- a/doc/api_reference.md
+++ b/doc/api_reference.md
@@ -109,8 +109,9 @@
 注意：
 
 - `apply` 會先寫完整 backup，再逐項執行 action，回傳每項成功/失敗。
+- `actions` / `directives` 各自都有上限（預設 20，可由 env 覆蓋）；`directives` 只會採用最後一個非空 instruction。
 - `directive` 會獨立寫入 `debug_directive.json`，不受 action 失敗影響。
-- `undo` 只支援最近一次 apply（同 debug unit，且 branch 要匹配）。
+- `undo` 只支援最近一次 apply（同 debug unit，且 branch 要匹配）；若 backup 的 `world_day` 損壞，會直接回 `400`，不會 fallback 到目前值。
 
 ## NPC / Events / Images
 

--- a/doc/api_reference.md
+++ b/doc/api_reference.md
@@ -93,6 +93,21 @@
 | POST | `/api/lore/chat/stream` | Lore 對話（SSE，含提案解析） | body: `messages` |
 | POST | `/api/lore/apply` | 批次套用 lore 提案 | body: `proposals` |
 
+## Debug Panel
+
+| Method | Path | 說明 | 主要參數 |
+|---|---|---|---|
+| GET | `/api/debug/session` | 取得 Debug session（依 blank root 單位） | `branch_id` |
+| POST | `/api/debug/chat/stream` | Debug 對話串流（SSE，server-owned history） | body: `branch_id`, `user_message` |
+| POST | `/api/debug/apply` | 套用勾選修正（逐項執行） | body: `branch_id`, `actions[]`, `directives[]` |
+| POST | `/api/debug/undo` | 回滾最近一次 Debug apply | body: `branch_id` |
+
+注意：
+
+- `apply` 會先寫完整 backup，再逐項執行 action，回傳每項成功/失敗。
+- `directive` 會獨立寫入 `debug_directive.json`，不受 action 失敗影響。
+- `undo` 只支援最近一次 apply（同 debug unit，且 branch 要匹配）。
+
 ## NPC / Events / Images
 
 | Method | Path | 說明 | 主要參數 |

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -76,8 +76,12 @@ Browser (static/app.js, templates/index.html)
   - `conversation_recap.json`
   - `world_day.json`
   - `dungeon_progress.json`
+  - `debug_directive.json`（一次性隱藏 Debug 劇情指令）
   - `gm_cheats.json`
   - `branch_config.json`
+- `debug_units/<debug_unit_id>/`
+  - `chat.json`（Debug 對話歷史，依 blank root 單位共用）
+  - `last_apply_backup.json`（最近一次 Debug apply 前完整快照，供 Undo）
 - `lore.db` / `events.db` / `usage.db`
 - `saves.json`
 - `images/`
@@ -100,6 +104,7 @@ Browser (static/app.js, templates/index.html)
 1. 寫入玩家訊息到分支 delta。
 2. 建構 system prompt（核心角色狀態 + lore + NPC 摘要 + recap + 副本上下文）。
 3. 對玩家訊息做 context augmentation（lore/events/GM 隱藏敘事計劃/npc 活動/state RAG/戰力提醒/骰子提示）。
+   - 若存在 `debug_directive.json`，會注入 `[Debug 修正指令（僅供 GM 內部參考，勿透露給玩家）]` 區塊（一次性）
    - state RAG 走檢索層限流（預設總筆數 30、NPC 類別上限 10）
    - `must_include_keys` 命中項目保底注入，不受類別上限限制
 4. 記錄 request trace，呼叫 LLM（stream 或 non-stream），再記錄 response trace。

--- a/doc/development.md
+++ b/doc/development.md
@@ -51,6 +51,7 @@ pytest
 pytest -m "not slow"
 pytest tests/test_api_routes.py
 pytest tests/test_extract_tags_async.py -q
+pytest tests/test_debug_api.py
 ```
 
 ### 目前測試範圍（重點）
@@ -89,7 +90,11 @@ pytest tests/test_extract_tags_async.py -q
 3. 若改了狀態/抽取格式，順手驗證：
    - `tests/test_state_update.py`
    - `tests/test_extract_tags_async.py`
-4. 若改 lore/event 搜尋，跑：
+4. 若改 Debug Panel（debug chat/apply/undo/directive），至少跑：
+   - `tests/test_debug_api.py`
+   - `tests/test_context_injection.py`
+   - `tests/test_compaction.py`
+5. 若改 lore/event 搜尋，跑：
    - `tests/test_lore_db.py`
    - `tests/test_event_db.py`
 

--- a/doc/game_mechanics.md
+++ b/doc/game_mechanics.md
@@ -209,7 +209,43 @@
 
 ---
 
-## 9. 存檔機制（Save/Load）
+## 9. Debug Panel（V1）
+
+### 9.1 作用域與資料
+
+- Debug 對話歷史以 blank root 為單位：`debug_units/<debug_unit_id>/chat.json`
+- 實際套用目標永遠是「目前 branch」：state / NPC / world_day / dungeon
+- V1 不處理 events，也不直接改 `gm_plan.json`
+
+### 9.2 套用與回滾
+
+- `POST /api/debug/apply` 採逐項執行：
+  - action 失敗不會中斷其他 action
+  - 全部跑完回傳逐項結果
+- 套用前會先寫完整備份：`last_apply_backup.json`
+  - 含 state / NPC / world_day / dungeon 完整快照
+- `POST /api/debug/undo` 僅回滾最近一次 apply（同 debug unit）
+
+### 9.3 劇情修正指令（Directive）
+
+- Debug 指令存於 branch：`debug_directive.json`（單一 active）
+- 下次主流程 `_build_augmented_message()` 會注入隱藏段落
+- `_process_gm_response()` 完成後自動清除，避免累積污染
+
+### 9.4 Branch 規則
+
+- `edit / regenerate`：複製 directive 到新分支
+- `promote`：保留 directive（同步到 parent 路徑）
+- 其他分支操作（create/blank/merge/delete/cleanup）：不複製 directive
+
+### 9.5 審計訊息
+
+- 每次 apply/undo 都會在主聊天寫一則 `message_type=debug_audit`
+- `debug_audit` 可見但不進 GM prompt、不進 compaction
+
+---
+
+## 10. 存檔機制（Save/Load）
 
 - `POST /api/saves` 會保存 snapshot（state/NPC/recap/world_day）
 - `load` 的語意是「切回原分支 + 狀態預覽」：
@@ -219,7 +255,7 @@
 
 ---
 
-## 10. 對話壓縮（Compaction）
+## 11. 對話壓縮（Compaction）
 
 檔案：`compaction.py`
 
@@ -230,7 +266,7 @@
 
 ---
 
-## 11. 副本系統（Dungeon）
+## 12. 副本系統（Dungeon）
 
 檔案：`dungeon_system.py` + `/api/dungeon/*`
 

--- a/doc/game_mechanics.md
+++ b/doc/game_mechanics.md
@@ -222,9 +222,11 @@
 - `POST /api/debug/apply` 採逐項執行：
   - action 失敗不會中斷其他 action
   - 全部跑完回傳逐項結果
+  - `actions` / `directives` payload 都有上限（預設 20）；directive 只保留最後一個有效 instruction
 - 套用前會先寫完整備份：`last_apply_backup.json`
   - 含 state / NPC / world_day / dungeon 完整快照
 - `POST /api/debug/undo` 僅回滾最近一次 apply（同 debug unit）
+  - 若 backup 的 `world_day` 無法解析，undo 直接失敗，不會 fallback 到當前值
 
 ### 9.3 劇情修正指令（Directive）
 

--- a/doc/prompt_design.md
+++ b/doc/prompt_design.md
@@ -258,6 +258,7 @@
   - `gm_plan.json`
   - 當前 `debug_directive.json`（若存在）
 - Debug 對話歷史由 server 端管理（`debug_units/<unit>/chat.json`），送 LLM 時僅取最近 20 則。
+- V1 目前直接注入完整 state / NPC / dungeon JSON，尚未做獨立 token budget；大型故事有 context 爆量風險。
 
 ### Debug Tag 契約
 

--- a/doc/prompt_design.md
+++ b/doc/prompt_design.md
@@ -234,3 +234,29 @@
 5. 若調整 tier 或 relationship 正規化規則，需同步更新：
    - `app.py::_normalize_npc_tier()` / `_rel_to_str()`
    - `state_db.py` 內對應 helper（目前為避免循環 import 採 duplicated logic）
+
+---
+
+## Debug Panel Prompt（V1）
+
+路由：`POST /api/debug/chat/stream`
+
+- 使用獨立 Debug system prompt（診斷/修正助手），與主 GM prompt 分離。
+- 每次呼叫會注入：
+  - 主聊天最近 `RECENT_MESSAGE_COUNT` 則（唯讀摘要）
+  - `character_state.json`（完整）
+  - `npcs.json`（含 archived）
+  - `world_day`
+  - `dungeon_progress.json`
+  - `gm_plan.json`
+  - 當前 `debug_directive.json`（若存在）
+- Debug 對話歷史由 server 端管理（`debug_units/<unit>/chat.json`），送 LLM 時僅取最近 20 則。
+
+### Debug Tag 契約
+
+- 修正提案：`<!--DEBUG_ACTION {...} DEBUG_ACTION-->`
+  - `type` 支援：`state_patch` / `npc_upsert` / `npc_delete` / `world_day_set` / `dungeon_patch`
+- 劇情指令：`<!--DEBUG_DIRECTIVE {"instruction":"..."} DEBUG_DIRECTIVE-->`
+  - apply 後寫入 branch `debug_directive.json`
+  - 下次主 GM 回合注入 `_build_augmented_message`
+  - 該回合完成後由 `_process_gm_response` 自動清除（一次性）

--- a/static/app.js
+++ b/static/app.js
@@ -4590,7 +4590,7 @@ function _renderInlineProposalCards(container) {
   });
 
   _debugPendingDirectives.forEach((d, i) => {
-    const text = d.instruction || "";
+    const text = (d.instruction || "").trim();
     const card = document.createElement("div");
     card.className = "proposal-card";
     card.innerHTML = `

--- a/static/app.js
+++ b/static/app.js
@@ -4552,6 +4552,30 @@ function _updateDebugApplyButton() {
   }
 }
 
+function _buildPendingSummary() {
+  const parts = [];
+  for (const p of _debugPendingProposals) {
+    if (p.type === "state_patch") {
+      parts.push(`- 狀態修改: ${JSON.stringify(p.update)}`);
+    } else if (p.type === "npc_upsert") {
+      parts.push(`- 新增/覆寫 NPC: ${p.npc_id}`);
+    } else if (p.type === "npc_delete") {
+      parts.push(`- 刪除 NPC: ${p.npc_id}`);
+    } else if (p.type === "world_day_set") {
+      parts.push(`- 修改天數為: ${p.day}`);
+    } else if (p.type === "dungeon_patch") {
+      parts.push(`- 副本進度: ${JSON.stringify(p.update)}`);
+    } else {
+      parts.push(`- 其他修改: ${p.type}`);
+    }
+  }
+  for (const d of _debugPendingDirectives) {
+    const text = d.instruction || "";
+    parts.push(`- 寫入劇情設定: ${text.length > 50 ? text.substring(0, 50) + "..." : text}`);
+  }
+  return parts.join("\n");
+}
+
 async function _loadDebugSession(resetSuggestions = true) {
   const res = await API.debugSession(currentBranchId);
   if (!res.ok) throw new Error(res.error || "載入 debug session 失敗");
@@ -4650,6 +4674,15 @@ async function sendDebugChat() {
 async function applyDebugChanges() {
   const result = document.getElementById("debug-apply-result");
   if (!result) return;
+
+  const total = _debugPendingProposals.length + _debugPendingDirectives.length;
+  if (total === 0) return;
+
+  const summary = _buildPendingSummary();
+  if (!await showConfirm(`AI 準備了 ${total} 項內部修改，確定要套用嗎？\n\n${summary}`)) {
+    return;
+  }
+
   try {
     const res = await API.debugApply(currentBranchId, _debugPendingProposals, _debugPendingDirectives);
     if (!res.ok) {
@@ -4659,7 +4692,7 @@ async function applyDebugChanges() {
     const failed = (res.results || []).filter(x => !x.ok);
     const failLines = failed.map(x => `- ${x.type}: ${x.error || "unknown error"}`);
     result.textContent = [res.audit_summary || "", ...failLines].filter(Boolean).join("\n");
-    showAlert(res.audit_summary || "變更套用成功！");
+    showAlert(res.audit_summary || `變更套用成功！已套用 ${total} 筆修正`);
     await loadMessages(currentBranchId);
     await _loadDebugSession();
   } catch (e) {

--- a/static/app.js
+++ b/static/app.js
@@ -4550,30 +4550,52 @@ function _updateDebugApplyButton() {
     btn.classList.remove("pulse-ready");
     btn.disabled = true;
   }
+  _renderDebugPendingOptions();
 }
 
-function _buildPendingSummary() {
-  const parts = [];
-  for (const p of _debugPendingProposals) {
-    if (p.type === "state_patch") {
-      parts.push(`- 狀態修改: ${JSON.stringify(p.update)}`);
-    } else if (p.type === "npc_upsert") {
-      parts.push(`- 新增/覆寫 NPC: ${p.npc_id}`);
-    } else if (p.type === "npc_delete") {
-      parts.push(`- 刪除 NPC: ${p.npc_id}`);
-    } else if (p.type === "world_day_set") {
-      parts.push(`- 修改天數為: ${p.day}`);
-    } else if (p.type === "dungeon_patch") {
-      parts.push(`- 副本進度: ${JSON.stringify(p.update)}`);
-    } else {
-      parts.push(`- 其他修改: ${p.type}`);
-    }
+function _renderDebugPendingOptions() {
+  const container = document.getElementById("debug-pending-options-container");
+  if (!container) return;
+
+  const count = _debugPendingProposals.length + _debugPendingDirectives.length;
+  if (count === 0) {
+    container.classList.add("hidden");
+    container.innerHTML = "";
+    return;
   }
-  for (const d of _debugPendingDirectives) {
+
+  let html = `<div class="debug-options-header">準備套用的修正列表 (${count})：</div>`;
+
+  _debugPendingProposals.forEach((p, i) => {
+    let text = "";
+    if (p.type === "state_patch") text = `狀態修改: ${JSON.stringify(p.update)}`;
+    else if (p.type === "npc_upsert") text = `新增/覆寫 NPC: ${p.npc_id}`;
+    else if (p.type === "npc_delete") text = `刪除 NPC: ${p.npc_id}`;
+    else if (p.type === "world_day_set") text = `修改天數為: ${p.day}`;
+    else if (p.type === "dungeon_patch") text = `副本進度: ${JSON.stringify(p.update)}`;
+    else text = `其他修改: ${p.type}`;
+
+    html += `
+      <label class="debug-option-item">
+        <input type="checkbox" class="debug-prop-cb" data-index="${i}" checked>
+        <span>${escapeHtml(text)}</span>
+      </label>
+    `;
+  });
+
+  _debugPendingDirectives.forEach((d, i) => {
     const text = d.instruction || "";
-    parts.push(`- 寫入劇情設定: ${text.length > 50 ? text.substring(0, 50) + "..." : text}`);
-  }
-  return parts.join("\n");
+    const shortText = text.length > 60 ? text.substring(0, 60) + "..." : text;
+    html += `
+      <label class="debug-option-item directive">
+        <input type="checkbox" class="debug-dir-cb" data-index="${i}" checked>
+        <span title="${escapeHtml(text)}">寫入劇情設定: ${escapeHtml(shortText)}</span>
+      </label>
+    `;
+  });
+
+  container.innerHTML = html;
+  container.classList.remove("hidden");
 }
 
 async function _loadDebugSession(resetSuggestions = true) {
@@ -4675,16 +4697,23 @@ async function applyDebugChanges() {
   const result = document.getElementById("debug-apply-result");
   if (!result) return;
 
-  const total = _debugPendingProposals.length + _debugPendingDirectives.length;
-  if (total === 0) return;
+  const selectedProposals = [];
+  document.querySelectorAll(".debug-prop-cb:checked").forEach(cb => {
+    selectedProposals.push(_debugPendingProposals[parseInt(cb.dataset.index, 10)]);
+  });
+  const selectedDirectives = [];
+  document.querySelectorAll(".debug-dir-cb:checked").forEach(cb => {
+    selectedDirectives.push(_debugPendingDirectives[parseInt(cb.dataset.index, 10)]);
+  });
 
-  const summary = _buildPendingSummary();
-  if (!await showConfirm(`AI 準備了 ${total} 項內部修改，確定要套用嗎？\n\n${summary}`)) {
+  const total = selectedProposals.length + selectedDirectives.length;
+  if (total === 0) {
+    showAlert("請至少選擇一項修正！");
     return;
   }
 
   try {
-    const res = await API.debugApply(currentBranchId, _debugPendingProposals, _debugPendingDirectives);
+    const res = await API.debugApply(currentBranchId, selectedProposals, selectedDirectives);
     if (!res.ok) {
       result.textContent = res.error || "套用失敗";
       return;

--- a/static/app.js
+++ b/static/app.js
@@ -179,6 +179,12 @@ const API = {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ branch_id: branchId || "main" }),
     }).then(r => r.json()),
+  debugDirectiveClear: (branchId) =>
+    fetch("/api/debug/directive/clear", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ branch_id: branchId || "main" }),
+    }).then(r => r.json()),
 
   switchBranch: (branchId) =>
     fetch("/api/branches/switch", {
@@ -1880,22 +1886,48 @@ async function submitEdit(msg, newText) {
 async function regenerateGmMessage(msg, msgEl) {
 
   const parentBranchId = msg.owner_branch_id || currentBranchId;
-  const branchPointIndex = msg.index - 1;
-
-  const contentEl = msgEl.querySelector(".content");
-  const actionBtn = msgEl.querySelector(".msg-action-btn");
-  if (contentEl) {
-    contentEl.innerHTML = '<span style="color:var(--text-dim);font-size:0.9rem">主神系統處理中<span class="typing-dots"><span></span><span></span><span></span></span></span>';
-  }
-  if (actionBtn) actionBtn.style.display = "none";
-  $sendBtn.disabled = true;
+  const branchPointIndex = (msg.role === 'user') ? msg.index : msg.index - 1;
 
   // Truncate subsequent messages in DOM
-  while (msgEl.nextSibling) {
-    msgEl.nextSibling.remove();
+  let sibling = msgEl.nextSibling;
+  while (sibling) {
+    let next = sibling.nextSibling;
+    sibling.remove();
+    sibling = next;
   }
 
-  showPlaceholderSwitcher(msgEl, msg.index);
+  let contentEl, actionsEl, targetMsgEl;
+  if (msg.role === 'user') {
+    // Create NEW GM bubble for results
+    const gmIndex = msg.index + 1;
+    targetMsgEl = document.createElement("div");
+    targetMsgEl.className = "message gm";
+    targetMsgEl.dataset.index = gmIndex;
+    targetMsgEl.innerHTML = `
+      <div class="role-tag">GM</div>
+      <span class="msg-index">#${gmIndex}</span>
+      <div class="content">
+        <span style="color:var(--text-dim);font-size:0.9rem">主神系統處理中<span class="typing-dots"><span></span><span></span><span></span></span></span>
+      </div>
+      <div class="msg-actions" style="display:none"></div>
+    `;
+    $messages.appendChild(targetMsgEl);
+    contentEl = targetMsgEl.querySelector(".content");
+    actionsEl = targetMsgEl.querySelector(".msg-actions");
+  } else {
+    // Standard behavior for existing GM message
+    targetMsgEl = msgEl;
+    contentEl = msgEl.querySelector(".content");
+    actionsEl = msgEl.querySelector(".msg-actions");
+    if (contentEl) {
+      contentEl.innerHTML = '<span style="color:var(--text-dim);font-size:0.9rem">主神系統處理中<span class="typing-dots"><span></span><span></span><span></span></span></span>';
+    }
+    if (actionsEl) actionsEl.style.display = "none";
+  }
+
+  $sendBtn.disabled = true;
+
+  showPlaceholderSwitcher(targetMsgEl, branchPointIndex + 1);
 
   if (activeStreamController) {
     activeStreamController.abort();
@@ -1931,7 +1963,7 @@ async function regenerateGmMessage(msg, msgEl) {
       (errMsg) => {
         if (errMsg !== "AbortError") {
           if (contentEl) contentEl.innerHTML = markdownToHtml(msg.content);
-          if (actionBtn) actionBtn.style.display = "";
+          if (actionsEl) actionsEl.style.display = "";
           loadBranches().then(() => renderBranchList());
           showAlert(errMsg || "重新生成失敗");
         }
@@ -1942,7 +1974,7 @@ async function regenerateGmMessage(msg, msgEl) {
   } catch (err) {
     if (err.name === 'AbortError') return;
     if (contentEl) contentEl.innerHTML = markdownToHtml(msg.content);
-    if (actionBtn) actionBtn.style.display = "";
+    if (actionsEl) actionsEl.style.display = "";
     showAlert("網路錯誤：" + err.message);
   }
 
@@ -2073,6 +2105,9 @@ function renderMessages(messages) {
       makeGmOptionsClickable(content);
     }
 
+    const actionsContainer = document.createElement("div");
+    actionsContainer.className = "msg-actions";
+
     const actionBtn = document.createElement("button");
     actionBtn.className = "msg-action-btn";
     if (msg.role === "user") {
@@ -2083,6 +2118,21 @@ function renderMessages(messages) {
         haptic();
         startEditing(el, msg);
       });
+      actionsContainer.appendChild(actionBtn);
+
+      // Add Regen/Retry button if it's the last user message (recovery from generation failure)
+      if (msg === messages[messages.length - 1]) {
+        const retryBtn = document.createElement("button");
+        retryBtn.className = "msg-action-btn msg-regen-btn";
+        retryBtn.textContent = "\u21BB";
+        retryBtn.title = "重新生成 (補發)";
+        retryBtn.addEventListener("click", (e) => {
+          e.stopPropagation();
+          haptic();
+          regenerateGmMessage(msg, el);
+        });
+        actionsContainer.appendChild(retryBtn);
+      }
     } else {
       actionBtn.textContent = "\u21BB";
       actionBtn.title = "重新生成";
@@ -2091,6 +2141,7 @@ function renderMessages(messages) {
         haptic();
         regenerateGmMessage(msg, el);
       });
+      actionsContainer.appendChild(actionBtn);
     }
 
     // Bug report button (#6)
@@ -2102,6 +2153,7 @@ function renderMessages(messages) {
       e.stopPropagation();
       showReportModal(msg);
     });
+    actionsContainer.appendChild(reportBtn);
 
     el.appendChild(roleTag);
     el.appendChild(indexLabel);
@@ -2112,8 +2164,7 @@ function renderMessages(messages) {
       renderMessageImage(el, msg, currentStoryId);
     }
 
-    el.appendChild(actionBtn);
-    el.appendChild(reportBtn);
+    el.appendChild(actionsContainer);
 
     if (hasSwitcher) {
       const group = siblingGroups[sibKey];
@@ -2951,6 +3002,19 @@ function renderDungeonPanel(data) {
   const exitBtn = document.getElementById("dungeon-exit-btn");
 
   if (!data.in_dungeon) {
+    // Check if we are in "Preparation" phase for a dungeon
+    const status = branches[currentBranchId]?.status_summary || "";
+    if (status.includes("準備") || status.includes("前往") || status.includes("備戰")) {
+      section.style.display = "block";
+      section.innerHTML = `
+        <div class="dungeon-overview preparation-mode">
+          <div class="dungeon-metric-label">🗺️ 任務狀態</div>
+          <div class="dungeon-metric-value">${escapeHtml(status)}</div>
+          <div class="dungeon-prep-hint">系統正在安排副本切換，請等待劇情推進。</div>
+        </div>
+      `;
+      return;
+    }
     section.style.display = "none";
     return;
   }
@@ -3299,6 +3363,20 @@ function initAddonPanel() {
   document.getElementById("debug-apply-btn")?.addEventListener("click", applyDebugChanges);
   document.getElementById("debug-undo-btn")?.addEventListener("click", undoDebugChanges);
   document.getElementById("debug-clear-btn")?.addEventListener("click", clearDebugSession);
+
+  // Toggle for pending directive
+  document.getElementById("debug-pending-directive-header")?.addEventListener("click", (e) => {
+    e.stopPropagation();
+    const container = document.getElementById("debug-pending-directive-container");
+    if (container) {
+      container.classList.toggle("expanded");
+    }
+  });
+
+  document.getElementById("debug-pending-directive-cancel")?.addEventListener("click", (e) => {
+    e.stopPropagation();
+    cancelPendingDirective();
+  });
   if (!btn || !panel) return;
 
   btn.addEventListener("click", (e) => {
@@ -4081,6 +4159,9 @@ async function sendMessage() {
           renderMessageImage(gmEl, gmMsg, currentStoryId, { fresh: true });
         }
 
+        const actionsContainer = document.createElement("div");
+        actionsContainer.className = "msg-actions";
+
         // Add regen button
         const actionBtn = document.createElement("button");
         actionBtn.className = "msg-action-btn";
@@ -4090,7 +4171,7 @@ async function sendMessage() {
           e.stopPropagation();
           regenerateGmMessage(gmMsg, gmEl);
         });
-        gmEl.appendChild(actionBtn);
+        actionsContainer.appendChild(actionBtn);
 
         // Add report button
         const reportBtn = document.createElement("button");
@@ -4101,7 +4182,9 @@ async function sendMessage() {
           e.stopPropagation();
           showReportModal(gmMsg);
         });
-        gmEl.appendChild(reportBtn);
+        actionsContainer.appendChild(reportBtn);
+
+        gmEl.appendChild(actionsContainer);
 
         // Only auto-scroll at the end if user was following along
         if (wasAtBottom && !userScrolledDuringStream) {
@@ -4163,12 +4246,14 @@ async function sendMessage() {
         container.removeEventListener('scroll', scrollHandler);
         gmEl.remove();
         appendSystemError(msg || "未知錯誤");
+        _addRetryButtonToLastUserMessage();
       }
     );
   } catch (err) {
     container.removeEventListener('scroll', scrollHandler);
     gmEl.remove();
     appendSystemError("網路錯誤：" + err.message);
+    _addRetryButtonToLastUserMessage();
   }
 
   isSending = false;
@@ -4212,6 +4297,9 @@ function appendMessage(msg) {
     makeGmOptionsClickable(content);
   }
 
+  const actionsContainer = document.createElement("div");
+  actionsContainer.className = "msg-actions";
+
   const actionBtn = document.createElement("button");
   actionBtn.className = "msg-action-btn";
   if (msg.role === "user") {
@@ -4221,6 +4309,7 @@ function appendMessage(msg) {
       e.stopPropagation();
       startEditing(el, msg);
     });
+    actionsContainer.appendChild(actionBtn);
   } else {
     actionBtn.textContent = "\u21BB";
     actionBtn.title = "重新生成";
@@ -4228,6 +4317,7 @@ function appendMessage(msg) {
       e.stopPropagation();
       regenerateGmMessage(msg, el);
     });
+    actionsContainer.appendChild(actionBtn);
   }
 
   const reportBtn = document.createElement("button");
@@ -4238,6 +4328,7 @@ function appendMessage(msg) {
     e.stopPropagation();
     showReportModal(msg);
   });
+  actionsContainer.appendChild(reportBtn);
 
   el.appendChild(roleTag);
   el.appendChild(indexLabel);
@@ -4248,9 +4339,33 @@ function appendMessage(msg) {
     renderMessageImage(el, msg, currentStoryId);
   }
 
-  el.appendChild(actionBtn);
-  el.appendChild(reportBtn);
+  el.appendChild(actionsContainer);
   $messages.appendChild(el);
+}
+
+function _addRetryButtonToLastUserMessage() {
+  const lastMsg = allMessages[allMessages.length - 1];
+  if (!lastMsg || lastMsg.role !== 'user') return;
+
+  const lastEl = $messages.querySelector(`.message[data-index="${lastMsg.index}"]`);
+  if (!lastEl) return;
+
+  const actionsContainer = lastEl.querySelector(".msg-actions");
+  if (!actionsContainer) return;
+
+  // Don't add if already exists
+  if (actionsContainer.querySelector(".msg-regen-btn")) return;
+
+  const retryBtn = document.createElement("button");
+  retryBtn.className = "msg-action-btn msg-regen-btn";
+  retryBtn.textContent = "\u21BB";
+  retryBtn.title = "重新生成 (補發)";
+  retryBtn.addEventListener("click", (e) => {
+    e.stopPropagation();
+    haptic();
+    regenerateGmMessage(lastMsg, lastEl);
+  });
+  actionsContainer.appendChild(retryBtn);
 }
 
 function appendSystemError(text) {
@@ -4518,9 +4633,13 @@ function _parseDebugContent(text) {
   let cleanText = text.replace(/<!--DEBUG_ACTION\s+([\s\S]*?)\s+DEBUG_ACTION-->/g, (match, jsonStr) => {
     try {
       const p = JSON.parse(jsonStr);
-      if (p.type === "state_patch" && typeof p.update === "object") {
-        for (const [key, value] of Object.entries(p.update)) {
-          proposals.push({ type: "state_patch", update: { [key]: value } });
+      // Support both 'update' and 'patch' keys for state_patch
+      if (p.type === "state_patch") {
+        const updateObj = p.update || p.patch;
+        if (updateObj && typeof updateObj === "object") {
+          for (const [key, value] of Object.entries(updateObj)) {
+            proposals.push({ type: "state_patch", update: { [key]: value } });
+          }
         }
       } else {
         proposals.push(p);
@@ -4595,10 +4714,13 @@ function _renderInlineProposalCards(container, proposals, directives) {
     let contentHtml = "";
 
     if (p.type === "state_patch") {
-      const key = Object.keys(p.update)[0];
-      const val = p.update[key];
-      topic = key;
-      contentHtml = `數值調整為: ${JSON.stringify(val)}`;
+      const updateObj = p.update || p.patch;
+      if (updateObj && typeof updateObj === "object") {
+        const key = Object.keys(updateObj)[0];
+        const val = updateObj[key];
+        topic = key;
+        contentHtml = `數值調整為: ${JSON.stringify(val)}`;
+      }
     } else if (p.type === "npc_upsert") {
       badgeClass = "add"; badgeText = "NPC";
       topic = (p.npc && (p.npc.name || p.npc.id)) || '未命名';
@@ -4678,6 +4800,15 @@ window.applySingleDebugAction = async function (type, payloadStr, btn) {
     card.classList.add("applied");
     card.querySelector(".proposal-actions").innerHTML = `<span style="color:#4caf50;font-size:0.85em;font-weight:bold;">✔ 已採用</span>`;
     await loadMessages(currentBranchId);
+    await _loadDebugSession(false); // Refresh debug session UI to show the new pending directive
+
+    // Refresh external UI (sidebar status, npcs, etc)
+    const status = await API.status(currentBranchId);
+    renderCharacterStatus(status);
+    updateWorldDayDisplay(status.world_day);
+    loadDungeonProgress();
+    loadNpcs();
+    loadEvents();
   } catch (e) {
     showAlert("套用失敗: " + e.message);
     btn.disabled = false;
@@ -4698,10 +4829,29 @@ async function _loadDebugSession(resetSuggestions = true) {
   document.getElementById("debug-target-branch").textContent = `branch: ${res.target_branch_id}`;
   document.getElementById("debug-unit-id").textContent = `unit: ${res.debug_unit_id}`;
   _renderDebugChatMessages(res.messages || []);
+  _renderPendingDirective(res.pending_directive);
   if (resetSuggestions) {
     _debugPendingProposals = [];
     _debugPendingDirectives = [];
   }
+}
+
+function _renderPendingDirective(directive) {
+  const container = document.getElementById("debug-pending-directive-container");
+  const content = document.getElementById("debug-pending-directive-content");
+  if (!container || !content) return;
+
+  const instruction = (directive?.instruction || "").trim();
+  if (!instruction) {
+    container.classList.add("hidden");
+    content.innerHTML = "";
+    return;
+  }
+
+  container.classList.remove("hidden");
+  // Keep collapsed by default on new load
+  container.classList.remove("expanded");
+  content.innerHTML = markdownToHtml(instruction);
 }
 
 async function openDebugPanel() {
@@ -4775,9 +4925,12 @@ async function sendDebugChat() {
         const rawProposals = data.proposals || [];
         const splitProposals = [];
         rawProposals.forEach(p => {
-          if (p.type === "state_patch" && typeof p.update === "object") {
-            for (const [key, value] of Object.entries(p.update)) {
-              splitProposals.push({ type: "state_patch", update: { [key]: value } });
+          if (p.type === "state_patch") {
+            const updateObj = p.update || p.patch;
+            if (updateObj && typeof updateObj === "object") {
+              for (const [key, value] of Object.entries(updateObj)) {
+                splitProposals.push({ type: "state_patch", update: { [key]: value } });
+              }
             }
           } else {
             splitProposals.push(p);
@@ -4789,6 +4942,11 @@ async function sendDebugChat() {
 
         if (gmNode) {
           _renderInlineProposalCards(gmNode, splitProposals, data.directives || []);
+        }
+
+        // Refresh pending directive if any was applied
+        if (data.directives && data.directives.length > 0) {
+          _loadDebugSession(false);
         }
       },
       (errMsg) => {
@@ -4802,6 +4960,16 @@ async function sendDebugChat() {
 }
 
 
+async function cancelPendingDirective() {
+  try {
+    const res = await API.debugDirectiveClear(currentBranchId);
+    if (!res.ok) throw new Error(res.error);
+    await _loadDebugSession(false);
+  } catch (e) {
+    showAlert("撤銷失敗: " + e.message);
+  }
+}
+
 async function undoDebugChanges() {
   const result = document.getElementById("debug-apply-result");
   if (!result) return;
@@ -4813,6 +4981,14 @@ async function undoDebugChanges() {
   result.textContent = res.audit_summary || "已回滾";
   await loadMessages(currentBranchId);
   await _loadDebugSession();
+
+  // Refresh external UI (sidebar status, npcs, etc)
+  const status = await API.status(currentBranchId);
+  renderCharacterStatus(status);
+  updateWorldDayDisplay(status.world_day);
+  loadDungeonProgress();
+  loadNpcs();
+  loadEvents();
 }
 
 async function clearDebugSession() {

--- a/static/app.js
+++ b/static/app.js
@@ -4630,7 +4630,6 @@ window.applySingleDebugAction = async function (type, index, btn) {
 
     card.classList.add("applied");
     card.querySelector(".proposal-actions").innerHTML = `<span style="color:#4caf50;font-size:0.85em;font-weight:bold;">✔ 已採用</span>`;
-    showAlert(res.audit_summary || "變更套用成功！");
     await loadMessages(currentBranchId);
   } catch (e) {
     showAlert("套用失敗: " + e.message);

--- a/static/app.js
+++ b/static/app.js
@@ -313,6 +313,12 @@ const API = {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ branch_id: branchId || "main" }),
     }).then(r => r.json()),
+  debugClear: (branchId) =>
+    fetch("/api/debug/clear", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ branch_id: branchId || "main" }),
+    }).then(r => r.json()),
 };
 
 // ---------------------------------------------------------------------------
@@ -1062,7 +1068,7 @@ function _btFindDeepestLeaf(startId, childrenOf) {
     const kids = (childrenOf[id] || []).filter(k => !k.deleted && !k.merged && !k.pruned);
     if (!kids.length) {
       if (depth > bestDepth || (depth === bestDepth && best &&
-          (branches[id]?.created_at || "") > (branches[best]?.created_at || ""))) {
+        (branches[id]?.created_at || "") > (branches[best]?.created_at || ""))) {
         best = id; bestDepth = depth;
       }
       return;
@@ -1558,78 +1564,78 @@ async function switchToBranch(branchId, { scrollToIndex, scrollBlock, preserveSc
 
   try {
 
-  const switchRes = await API.switchBranch(branchId);
-  if (!switchRes.ok) {
-    showAlert(switchRes.error || "切換分支失敗");
-    return;
-  }
-  currentBranchId = branchId;
-  updateBranchIndicator();
-  renderBranchList();
+    const switchRes = await API.switchBranch(branchId);
+    if (!switchRes.ok) {
+      showAlert(switchRes.error || "切換分支失敗");
+      return;
+    }
+    currentBranchId = branchId;
+    updateBranchIndicator();
+    renderBranchList();
 
-  if (scrollToIndex != null || preserveScroll) {
-    $messages.style.minHeight = $messages.scrollHeight + "px";
-  }
+    if (scrollToIndex != null || preserveScroll) {
+      $messages.style.minHeight = $messages.scrollHeight + "px";
+    }
 
-  if (isAutoBranch(branchId)) {
-    await loadMessages(branchId, { tail: 100 });
-  } else {
-    await loadMessages(branchId);
-  }
-  const status = await API.status(branchId);
-  renderCharacterStatus(status);
-  loadNpcs();
-  loadEvents();
-  loadDungeonProgress();
-  loadSummaries();
-  loadFateModeStatus();
-  loadDiceCheatStatus();
-  loadPistolModeStatus();
-
-  // Show/hide "load earlier" button for auto branches with truncated messages
-  if (isAutoBranch(branchId) && allMessages.length < totalMessages) {
-    $loadBtn.style.display = "";
-    $loadBtn.onclick = async () => {
-      $loadBtn.style.display = "none";
-      await loadMessages(branchId);
-      scrollToBottom();
-    };
-  } else {
-    $loadBtn.style.display = "none";
-  }
-
-  if (isAutoBranch(branchId)) {
-    startLivePolling(branchId);
-  } else {
-    stopLivePolling();
-  }
-
-  if (forcePreserve) {
-    // Keep current scroll position — user may have scrolled during streaming
-    const currentScroll = container.scrollTop;
-    requestAnimationFrame(() => {
-      container.scrollTop = currentScroll;
-      $messages.style.minHeight = "";
-      fadeIn();
-    });
-    return;
-  }
-
-  if (preserveScroll) {
-    if (isAtBottom) {
-      scrollToBottom();
-      $messages.style.minHeight = "";
-      requestAnimationFrame(() => { fadeIn(); });
+    if (isAutoBranch(branchId)) {
+      await loadMessages(branchId, { tail: 100 });
     } else {
-      container.scrollTop = savedScrollTop;
+      await loadMessages(branchId);
+    }
+    const status = await API.status(branchId);
+    renderCharacterStatus(status);
+    loadNpcs();
+    loadEvents();
+    loadDungeonProgress();
+    loadSummaries();
+    loadFateModeStatus();
+    loadDiceCheatStatus();
+    loadPistolModeStatus();
+
+    // Show/hide "load earlier" button for auto branches with truncated messages
+    if (isAutoBranch(branchId) && allMessages.length < totalMessages) {
+      $loadBtn.style.display = "";
+      $loadBtn.onclick = async () => {
+        $loadBtn.style.display = "none";
+        await loadMessages(branchId);
+        scrollToBottom();
+      };
+    } else {
+      $loadBtn.style.display = "none";
+    }
+
+    if (isAutoBranch(branchId)) {
+      startLivePolling(branchId);
+    } else {
+      stopLivePolling();
+    }
+
+    if (forcePreserve) {
+      // Keep current scroll position — user may have scrolled during streaming
+      const currentScroll = container.scrollTop;
       requestAnimationFrame(() => {
-        container.scrollTop = savedScrollTop;
+        container.scrollTop = currentScroll;
         $messages.style.minHeight = "";
         fadeIn();
       });
+      return;
     }
-    return;
-  }
+
+    if (preserveScroll) {
+      if (isAtBottom) {
+        scrollToBottom();
+        $messages.style.minHeight = "";
+        requestAnimationFrame(() => { fadeIn(); });
+      } else {
+        container.scrollTop = savedScrollTop;
+        requestAnimationFrame(() => {
+          container.scrollTop = savedScrollTop;
+          $messages.style.minHeight = "";
+          fadeIn();
+        });
+      }
+      return;
+    }
 
   } catch (err) {
     fadeIn();
@@ -2024,7 +2030,7 @@ function renderMessages(messages) {
       }
     }
 
-    if (msg.message_type === "debug_audit") {
+    if (msg.message_type === "debug_audit" || msg.role === "system") {
       $messages.appendChild(createDebugAuditMessageElement(msg));
       continue;
     }
@@ -3293,6 +3299,7 @@ function initAddonPanel() {
   });
   document.getElementById("debug-apply-btn")?.addEventListener("click", applyDebugChanges);
   document.getElementById("debug-undo-btn")?.addEventListener("click", undoDebugChanges);
+  document.getElementById("debug-clear-btn")?.addEventListener("click", clearDebugSession);
 }
 
 async function openAddonPanel() {
@@ -3311,6 +3318,14 @@ function closeAddonPanel() {
   if (btn) btn.setAttribute("aria-expanded", "false");
 }
 
+function stripDebugTags(text) {
+  if (!text) return "";
+  return text
+    .replace(/<!--DEBUG_ACTION[\s\S]*?DEBUG_ACTION-->/g, "")
+    .replace(/<!--DEBUG_DIRECTIVE[\s\S]*?DEBUG_DIRECTIVE-->/g, "")
+    .trim();
+}
+
 function _renderDebugChatMessages(messages) {
   const box = document.getElementById("debug-chat-messages");
   if (!box) return;
@@ -3322,7 +3337,8 @@ function _renderDebugChatMessages(messages) {
     role.className = "debug-chat-role";
     role.textContent = msg.role === "user" ? "玩家" : "Debug GM";
     const content = document.createElement("div");
-    content.innerHTML = markdownToHtml(msg.content || "");
+    const cleanContent = msg.role === "assistant" ? stripDebugTags(msg.content) : msg.content;
+    content.innerHTML = markdownToHtml(cleanContent || "");
     node.appendChild(role);
     node.appendChild(content);
     box.appendChild(node);
@@ -3330,82 +3346,6 @@ function _renderDebugChatMessages(messages) {
   box.scrollTop = box.scrollHeight;
 }
 
-function _createDebugItemNode(item, idx, kind) {
-  const wrap = document.createElement("div");
-  wrap.className = "debug-item";
-
-  const head = document.createElement("div");
-  head.className = "debug-item-head";
-
-  const checkbox = document.createElement("input");
-  checkbox.type = "checkbox";
-  checkbox.checked = true;
-  checkbox.dataset.kind = kind;
-  checkbox.dataset.index = String(idx);
-
-  const label = document.createElement("span");
-  if (kind === "action") {
-    label.textContent = item.type || `action_${idx + 1}`;
-  } else {
-    label.textContent = `directive_${idx + 1}`;
-  }
-
-  const textarea = document.createElement("textarea");
-  textarea.className = "debug-item-json";
-  textarea.dataset.kind = kind;
-  textarea.dataset.index = String(idx);
-  textarea.value = JSON.stringify(item, null, 2);
-
-  head.appendChild(checkbox);
-  head.appendChild(label);
-  wrap.appendChild(head);
-  wrap.appendChild(textarea);
-  return wrap;
-}
-
-function _renderDebugProposals() {
-  const actionsBox = document.getElementById("debug-proposals");
-  const directivesBox = document.getElementById("debug-directives");
-  if (!actionsBox || !directivesBox) return;
-
-  actionsBox.innerHTML = "";
-  directivesBox.innerHTML = "";
-
-  if (!_debugPendingProposals.length) {
-    actionsBox.textContent = "（目前無提案）";
-  } else {
-    _debugPendingProposals.forEach((item, idx) => {
-      actionsBox.appendChild(_createDebugItemNode(item, idx, "action"));
-    });
-  }
-
-  if (!_debugPendingDirectives.length) {
-    directivesBox.textContent = "（目前無指令）";
-  } else {
-    _debugPendingDirectives.forEach((item, idx) => {
-      directivesBox.appendChild(_createDebugItemNode(item, idx, "directive"));
-    });
-  }
-}
-
-function _collectDebugSelectedItems(kind) {
-  const modal = document.getElementById("debug-panel-modal");
-  if (!modal) return [];
-  const checked = modal.querySelectorAll(`input[type="checkbox"][data-kind="${kind}"]:checked`);
-  const items = [];
-  for (const cb of checked) {
-    const idx = cb.dataset.index;
-    const ta = modal.querySelector(`textarea.debug-item-json[data-kind="${kind}"][data-index="${idx}"]`);
-    if (!ta) continue;
-    try {
-      const parsed = JSON.parse(ta.value);
-      items.push(parsed);
-    } catch (e) {
-      throw new Error(`${kind} #${Number(idx) + 1} JSON 格式錯誤`);
-    }
-  }
-  return items;
-}
 
 async function _loadDebugSession(resetSuggestions = true) {
   const res = await API.debugSession(currentBranchId);
@@ -3418,7 +3358,6 @@ async function _loadDebugSession(resetSuggestions = true) {
     _debugPendingProposals = [];
     _debugPendingDirectives = [];
   }
-  _renderDebugProposals();
 }
 
 async function openDebugPanel() {
@@ -3456,11 +3395,12 @@ async function sendDebugChat() {
 
   const gmNode = document.createElement("div");
   gmNode.className = "debug-chat-msg assistant";
-  gmNode.innerHTML = `<div class="debug-chat-role">Debug GM</div><div class="debug-chat-stream"></div>`;
+  gmNode.innerHTML = `<div class="debug-chat-role">Debug GM</div><div class="debug-chat-stream"><span class="debug-thinking">Thinking...</span></div>`;
   box.appendChild(gmNode);
   box.scrollTop = box.scrollHeight;
 
   let streamed = "";
+  let isFirstChunk = true;
   try {
     await streamFromSSE(
       "/api/debug/chat/stream",
@@ -3468,16 +3408,27 @@ async function sendDebugChat() {
       (chunk) => {
         streamed += chunk;
         const target = gmNode.querySelector(".debug-chat-stream");
-        if (target) target.innerHTML = markdownToHtml(streamed);
+        if (target) {
+          if (isFirstChunk) {
+            target.innerHTML = "";
+            isFirstChunk = false;
+          }
+          target.innerHTML = markdownToHtml(stripDebugTags(streamed));
+        }
         box.scrollTop = box.scrollHeight;
       },
       async (data) => {
         const finalText = data.response || streamed;
         const target = gmNode.querySelector(".debug-chat-stream");
-        if (target) target.innerHTML = markdownToHtml(finalText);
+        if (target) {
+          if (isFirstChunk) {
+            target.innerHTML = "";
+            isFirstChunk = false;
+          }
+          target.innerHTML = markdownToHtml(stripDebugTags(finalText));
+        }
         _debugPendingProposals = data.proposals || [];
         _debugPendingDirectives = data.directives || [];
-        _renderDebugProposals();
         await _loadDebugSession(false);
       },
       (errMsg) => {
@@ -3494,9 +3445,7 @@ async function applyDebugChanges() {
   const result = document.getElementById("debug-apply-result");
   if (!result) return;
   try {
-    const actions = _collectDebugSelectedItems("action");
-    const directives = _collectDebugSelectedItems("directive");
-    const res = await API.debugApply(currentBranchId, actions, directives);
+    const res = await API.debugApply(currentBranchId, _debugPendingProposals, _debugPendingDirectives);
     if (!res.ok) {
       result.textContent = res.error || "套用失敗";
       return;
@@ -3504,6 +3453,7 @@ async function applyDebugChanges() {
     const failed = (res.results || []).filter(x => !x.ok);
     const failLines = failed.map(x => `- ${x.type}: ${x.error || "unknown error"}`);
     result.textContent = [res.audit_summary || "", ...failLines].filter(Boolean).join("\n");
+    showAlert(res.audit_summary || "變更套用成功！");
     await loadMessages(currentBranchId);
     await _loadDebugSession();
   } catch (e) {
@@ -3521,6 +3471,20 @@ async function undoDebugChanges() {
   }
   result.textContent = res.audit_summary || "已回滾";
   await loadMessages(currentBranchId);
+  await _loadDebugSession();
+}
+
+async function clearDebugSession() {
+  const result = document.getElementById("debug-apply-result");
+  if (!result) return;
+  if (!await showConfirm("確定要清空 Debug 對話紀錄嗎？（不影響已套用的改變）")) return;
+
+  const res = await API.debugClear(currentBranchId);
+  if (!res.ok) {
+    result.textContent = res.error || "清除失敗";
+    return;
+  }
+  result.textContent = res.audit_summary || "已清除";
   await _loadDebugSession();
 }
 
@@ -3788,7 +3752,7 @@ async function savePistolPrefs() {
     const prev = await fetch("/api/nsfw-preferences");
     const prevData = await prev.json();
     chipCounts = prevData.chip_counts || {};
-  } catch (_) {}
+  } catch (_) { }
   for (const c of chipsFlat) {
     chipCounts[c] = (chipCounts[c] || 0) + 1;
   }
@@ -4218,7 +4182,7 @@ function appendMessage(msg) {
     }
   }
 
-  if (msg.message_type === "debug_audit") {
+  if (msg.message_type === "debug_audit" || msg.role === "system") {
     $messages.appendChild(createDebugAuditMessageElement(msg));
     return;
   }

--- a/static/app.js
+++ b/static/app.js
@@ -4569,9 +4569,9 @@ function _renderDebugPendingOptions() {
   _debugPendingProposals.forEach((p, i) => {
     let text = "";
     if (p.type === "state_patch") text = `狀態修改: ${JSON.stringify(p.update)}`;
-    else if (p.type === "npc_upsert") text = `新增/覆寫 NPC: ${p.npc_id}`;
+    else if (p.type === "npc_upsert") text = `新增/覆寫 NPC: ${(p.npc && (p.npc.name || p.npc.id)) || '未命名'}`;
     else if (p.type === "npc_delete") text = `刪除 NPC: ${p.npc_id}`;
-    else if (p.type === "world_day_set") text = `修改天數為: ${p.day}`;
+    else if (p.type === "world_day_set") text = `修改天數為: ${p.day || p.world_day}`;
     else if (p.type === "dungeon_patch") text = `副本進度: ${JSON.stringify(p.update)}`;
     else text = `其他修改: ${p.type}`;
 

--- a/static/app.js
+++ b/static/app.js
@@ -2073,6 +2073,11 @@ function renderMessages(messages) {
       }
     }
 
+    if (msg.message_type === "debug_audit") {
+      $messages.appendChild(createDebugAuditMessageElement(msg));
+      continue;
+    }
+
     const el = document.createElement("div");
     el.className = `message ${msg.role}`;
     if (msg.inherited) el.classList.add("inherited");

--- a/static/app.js
+++ b/static/app.js
@@ -1078,7 +1078,7 @@ function _btFindDeepestLeaf(startId, childrenOf) {
     const kids = (childrenOf[id] || []).filter(k => !k.deleted && !k.merged && !k.pruned);
     if (!kids.length) {
       if (depth > bestDepth || (depth === bestDepth && best &&
-          (branches[id]?.created_at || "") > (branches[best]?.created_at || ""))) {
+        (branches[id]?.created_at || "") > (branches[best]?.created_at || ""))) {
         best = id; bestDepth = depth;
       }
       return;
@@ -1574,79 +1574,79 @@ async function switchToBranch(branchId, { scrollToIndex, scrollBlock, preserveSc
 
   try {
 
-  const switchRes = await API.switchBranch(branchId);
-  if (!switchRes.ok) {
-    showAlert(switchRes.error || "切換分支失敗");
-    return;
-  }
-  currentBranchId = branchId;
-  updateBranchIndicator();
-  renderBranchList();
+    const switchRes = await API.switchBranch(branchId);
+    if (!switchRes.ok) {
+      showAlert(switchRes.error || "切換分支失敗");
+      return;
+    }
+    currentBranchId = branchId;
+    updateBranchIndicator();
+    renderBranchList();
 
-  if (scrollToIndex != null || preserveScroll) {
-    $messages.style.minHeight = $messages.scrollHeight + "px";
-  }
+    if (scrollToIndex != null || preserveScroll) {
+      $messages.style.minHeight = $messages.scrollHeight + "px";
+    }
 
-  if (isAutoBranch(branchId)) {
-    await loadMessages(branchId, { tail: 100 });
-  } else {
-    await loadMessages(branchId);
-  }
-  const status = await API.status(branchId);
-  renderCharacterStatus(status);
-  loadNpcs();
-  loadEvents();
-  loadDungeonProgress();
-  loadSummaries();
-  loadFateModeStatus();
-  loadDiceCheatStatus();
-  loadPistolModeStatus();
-  loadImageGenAddonState();
-
-  // Show/hide "load earlier" button for auto branches with truncated messages
-  if (isAutoBranch(branchId) && allMessages.length < totalMessages) {
-    $loadBtn.style.display = "";
-    $loadBtn.onclick = async () => {
-      $loadBtn.style.display = "none";
-      await loadMessages(branchId);
-      scrollToBottom();
-    };
-  } else {
-    $loadBtn.style.display = "none";
-  }
-
-  if (isAutoBranch(branchId)) {
-    startLivePolling(branchId);
-  } else {
-    stopLivePolling();
-  }
-
-  if (forcePreserve) {
-    // Keep current scroll position — user may have scrolled during streaming
-    const currentScroll = container.scrollTop;
-    requestAnimationFrame(() => {
-      container.scrollTop = currentScroll;
-      $messages.style.minHeight = "";
-      fadeIn();
-    });
-    return;
-  }
-
-  if (preserveScroll) {
-    if (isAtBottom) {
-      scrollToBottom();
-      $messages.style.minHeight = "";
-      requestAnimationFrame(() => { fadeIn(); });
+    if (isAutoBranch(branchId)) {
+      await loadMessages(branchId, { tail: 100 });
     } else {
-      container.scrollTop = savedScrollTop;
+      await loadMessages(branchId);
+    }
+    const status = await API.status(branchId);
+    renderCharacterStatus(status);
+    loadNpcs();
+    loadEvents();
+    loadDungeonProgress();
+    loadSummaries();
+    loadFateModeStatus();
+    loadDiceCheatStatus();
+    loadPistolModeStatus();
+    loadImageGenAddonState();
+
+    // Show/hide "load earlier" button for auto branches with truncated messages
+    if (isAutoBranch(branchId) && allMessages.length < totalMessages) {
+      $loadBtn.style.display = "";
+      $loadBtn.onclick = async () => {
+        $loadBtn.style.display = "none";
+        await loadMessages(branchId);
+        scrollToBottom();
+      };
+    } else {
+      $loadBtn.style.display = "none";
+    }
+
+    if (isAutoBranch(branchId)) {
+      startLivePolling(branchId);
+    } else {
+      stopLivePolling();
+    }
+
+    if (forcePreserve) {
+      // Keep current scroll position — user may have scrolled during streaming
+      const currentScroll = container.scrollTop;
       requestAnimationFrame(() => {
-        container.scrollTop = savedScrollTop;
+        container.scrollTop = currentScroll;
         $messages.style.minHeight = "";
         fadeIn();
       });
+      return;
     }
-    return;
-  }
+
+    if (preserveScroll) {
+      if (isAtBottom) {
+        scrollToBottom();
+        $messages.style.minHeight = "";
+        requestAnimationFrame(() => { fadeIn(); });
+      } else {
+        container.scrollTop = savedScrollTop;
+        requestAnimationFrame(() => {
+          container.scrollTop = savedScrollTop;
+          $messages.style.minHeight = "";
+          fadeIn();
+        });
+      }
+      return;
+    }
 
   } catch (err) {
     fadeIn();
@@ -3278,7 +3278,7 @@ function _syncDiceToggleDisabled(disabled) {
 function initAddonPanel() {
   const btn = document.getElementById("addon-panel-btn");
   const panel = document.getElementById("addon-panel");
-  
+
   document.getElementById("addon-debug-btn")?.addEventListener("click", async () => {
     haptic();
     await openDebugPanel();
@@ -3361,7 +3361,7 @@ function initAddonPanel() {
 
 async function openAddonPanel() {
   const panel = document.getElementById("addon-panel");
-  
+
   document.getElementById("addon-debug-btn")?.addEventListener("click", async () => {
     haptic();
     await openDebugPanel();
@@ -3391,7 +3391,7 @@ async function openAddonPanel() {
 
 function closeAddonPanel() {
   const panel = document.getElementById("addon-panel");
-  
+
   document.getElementById("addon-debug-btn")?.addEventListener("click", async () => {
     haptic();
     await openDebugPanel();
@@ -3754,7 +3754,7 @@ async function savePistolPrefs() {
     const prev = await fetch("/api/nsfw-preferences");
     const prevData = await prev.json();
     chipCounts = prevData.chip_counts || {};
-  } catch (_) {}
+  } catch (_) { }
   for (const c of chipsFlat) {
     chipCounts[c] = (chipCounts[c] || 0) + 1;
   }
@@ -4537,6 +4537,21 @@ function _renderDebugChatMessages(messages) {
   box.scrollTop = box.scrollHeight;
 }
 
+function _updateDebugApplyButton() {
+  const btn = document.getElementById("debug-apply-btn");
+  if (!btn) return;
+  const count = _debugPendingProposals.length + _debugPendingDirectives.length;
+  if (count > 0) {
+    btn.textContent = `套用修正 (${count} 筆)`;
+    btn.classList.add("pulse-ready");
+    btn.disabled = false;
+  } else {
+    btn.textContent = "目前無待套用修正";
+    btn.classList.remove("pulse-ready");
+    btn.disabled = true;
+  }
+}
+
 async function _loadDebugSession(resetSuggestions = true) {
   const res = await API.debugSession(currentBranchId);
   if (!res.ok) throw new Error(res.error || "載入 debug session 失敗");
@@ -4548,6 +4563,7 @@ async function _loadDebugSession(resetSuggestions = true) {
     _debugPendingProposals = [];
     _debugPendingDirectives = [];
   }
+  _updateDebugApplyButton();
 }
 
 async function openDebugPanel() {

--- a/static/app.js
+++ b/static/app.js
@@ -293,6 +293,26 @@ const API = {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ branch_id: branchId }),
     }).then(r => r.json()),
+
+  // Debug Panel
+  debugSession: (branchId) =>
+    fetch(`/api/debug/session?branch_id=${branchId || "main"}`).then(r => r.json()),
+  debugApply: (branchId, actions, directives) =>
+    fetch("/api/debug/apply", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        branch_id: branchId || "main",
+        actions: actions || [],
+        directives: directives || [],
+      }),
+    }).then(r => r.json()),
+  debugUndo: (branchId) =>
+    fetch("/api/debug/undo", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ branch_id: branchId || "main" }),
+    }).then(r => r.json()),
 };
 
 // ---------------------------------------------------------------------------
@@ -378,6 +398,11 @@ let _livePollingBranchId = null;
 // Incomplete branch polling state (edit/regen interrupted)
 let _incompletePollTimer = null;
 let _incompletePollBranchId = null;
+
+// Debug panel state
+let _debugSession = null;
+let _debugPendingProposals = [];
+let _debugPendingDirectives = [];
 
 function isAutoBranch(branchId) {
   return branchId && branchId.startsWith("auto_");
@@ -1946,6 +1971,29 @@ function showPlaceholderSwitcher(msgEl, index) {
   msgEl.appendChild(switcher);
 }
 
+function createDebugAuditMessageElement(msg) {
+  const el = document.createElement("div");
+  el.className = "message debug-audit";
+  el.dataset.index = msg.index;
+
+  const roleTag = document.createElement("div");
+  roleTag.className = "role-tag";
+  roleTag.textContent = "系統";
+
+  const indexLabel = document.createElement("span");
+  indexLabel.className = "msg-index";
+  indexLabel.textContent = `#${msg.index}`;
+
+  const content = document.createElement("div");
+  content.className = "content";
+  content.innerHTML = markdownToHtml(msg.content || "");
+
+  el.appendChild(roleTag);
+  el.appendChild(indexLabel);
+  el.appendChild(content);
+  return el;
+}
+
 // ---------------------------------------------------------------------------
 // Render messages
 // ---------------------------------------------------------------------------
@@ -1974,6 +2022,11 @@ function renderMessages(messages) {
         $messages.appendChild(bpDiv);
         branchDividerInserted = true;
       }
+    }
+
+    if (msg.message_type === "debug_audit") {
+      $messages.appendChild(createDebugAuditMessageElement(msg));
+      continue;
     }
 
     const el = document.createElement("div");
@@ -3183,6 +3236,11 @@ function initAddonPanel() {
   // Prevent panel clicks from closing
   panel.addEventListener("click", (e) => e.stopPropagation());
 
+  document.getElementById("addon-debug-btn")?.addEventListener("click", async () => {
+    haptic();
+    await openDebugPanel();
+  });
+
   // Pistol prefs modal: chip toggles + close handlers
   const prefsModal = document.getElementById("pistol-prefs-modal");
   if (prefsModal) {
@@ -3220,6 +3278,21 @@ function initAddonPanel() {
       });
     });
   }
+
+  const debugModal = document.getElementById("debug-panel-modal");
+  document.getElementById("debug-panel-close")?.addEventListener("click", closeDebugPanel);
+  debugModal?.addEventListener("click", (e) => {
+    if (e.target === debugModal) closeDebugPanel();
+  });
+  document.getElementById("debug-chat-send")?.addEventListener("click", sendDebugChat);
+  document.getElementById("debug-chat-input")?.addEventListener("keydown", (e) => {
+    if ((e.ctrlKey || e.metaKey) && e.key === "Enter") {
+      e.preventDefault();
+      sendDebugChat();
+    }
+  });
+  document.getElementById("debug-apply-btn")?.addEventListener("click", applyDebugChanges);
+  document.getElementById("debug-undo-btn")?.addEventListener("click", undoDebugChanges);
 }
 
 async function openAddonPanel() {
@@ -3236,6 +3309,219 @@ function closeAddonPanel() {
   if (panel) panel.classList.add("hidden");
   const btn = document.getElementById("addon-panel-btn");
   if (btn) btn.setAttribute("aria-expanded", "false");
+}
+
+function _renderDebugChatMessages(messages) {
+  const box = document.getElementById("debug-chat-messages");
+  if (!box) return;
+  box.innerHTML = "";
+  for (const msg of messages || []) {
+    const node = document.createElement("div");
+    node.className = `debug-chat-msg ${msg.role === "user" ? "user" : "assistant"}`;
+    const role = document.createElement("div");
+    role.className = "debug-chat-role";
+    role.textContent = msg.role === "user" ? "玩家" : "Debug GM";
+    const content = document.createElement("div");
+    content.innerHTML = markdownToHtml(msg.content || "");
+    node.appendChild(role);
+    node.appendChild(content);
+    box.appendChild(node);
+  }
+  box.scrollTop = box.scrollHeight;
+}
+
+function _createDebugItemNode(item, idx, kind) {
+  const wrap = document.createElement("div");
+  wrap.className = "debug-item";
+
+  const head = document.createElement("div");
+  head.className = "debug-item-head";
+
+  const checkbox = document.createElement("input");
+  checkbox.type = "checkbox";
+  checkbox.checked = true;
+  checkbox.dataset.kind = kind;
+  checkbox.dataset.index = String(idx);
+
+  const label = document.createElement("span");
+  if (kind === "action") {
+    label.textContent = item.type || `action_${idx + 1}`;
+  } else {
+    label.textContent = `directive_${idx + 1}`;
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.className = "debug-item-json";
+  textarea.dataset.kind = kind;
+  textarea.dataset.index = String(idx);
+  textarea.value = JSON.stringify(item, null, 2);
+
+  head.appendChild(checkbox);
+  head.appendChild(label);
+  wrap.appendChild(head);
+  wrap.appendChild(textarea);
+  return wrap;
+}
+
+function _renderDebugProposals() {
+  const actionsBox = document.getElementById("debug-proposals");
+  const directivesBox = document.getElementById("debug-directives");
+  if (!actionsBox || !directivesBox) return;
+
+  actionsBox.innerHTML = "";
+  directivesBox.innerHTML = "";
+
+  if (!_debugPendingProposals.length) {
+    actionsBox.textContent = "（目前無提案）";
+  } else {
+    _debugPendingProposals.forEach((item, idx) => {
+      actionsBox.appendChild(_createDebugItemNode(item, idx, "action"));
+    });
+  }
+
+  if (!_debugPendingDirectives.length) {
+    directivesBox.textContent = "（目前無指令）";
+  } else {
+    _debugPendingDirectives.forEach((item, idx) => {
+      directivesBox.appendChild(_createDebugItemNode(item, idx, "directive"));
+    });
+  }
+}
+
+function _collectDebugSelectedItems(kind) {
+  const modal = document.getElementById("debug-panel-modal");
+  if (!modal) return [];
+  const checked = modal.querySelectorAll(`input[type="checkbox"][data-kind="${kind}"]:checked`);
+  const items = [];
+  for (const cb of checked) {
+    const idx = cb.dataset.index;
+    const ta = modal.querySelector(`textarea.debug-item-json[data-kind="${kind}"][data-index="${idx}"]`);
+    if (!ta) continue;
+    try {
+      const parsed = JSON.parse(ta.value);
+      items.push(parsed);
+    } catch (e) {
+      throw new Error(`${kind} #${Number(idx) + 1} JSON 格式錯誤`);
+    }
+  }
+  return items;
+}
+
+async function _loadDebugSession(resetSuggestions = true) {
+  const res = await API.debugSession(currentBranchId);
+  if (!res.ok) throw new Error(res.error || "載入 debug session 失敗");
+  _debugSession = res;
+  document.getElementById("debug-target-branch").textContent = `branch: ${res.target_branch_id}`;
+  document.getElementById("debug-unit-id").textContent = `unit: ${res.debug_unit_id}`;
+  _renderDebugChatMessages(res.messages || []);
+  if (resetSuggestions) {
+    _debugPendingProposals = [];
+    _debugPendingDirectives = [];
+  }
+  _renderDebugProposals();
+}
+
+async function openDebugPanel() {
+  closeAddonPanel();
+  const modal = document.getElementById("debug-panel-modal");
+  if (!modal) return;
+  modal.classList.remove("hidden");
+  document.getElementById("debug-apply-result").textContent = "";
+  await _loadDebugSession();
+}
+
+function closeDebugPanel() {
+  const modal = document.getElementById("debug-panel-modal");
+  if (!modal) return;
+  modal.classList.add("hidden");
+}
+
+async function sendDebugChat() {
+  const input = document.getElementById("debug-chat-input");
+  const sendBtn = document.getElementById("debug-chat-send");
+  const box = document.getElementById("debug-chat-messages");
+  const result = document.getElementById("debug-apply-result");
+  if (!input || !sendBtn || !box || !result) return;
+
+  const text = input.value.trim();
+  if (!text) return;
+  input.value = "";
+  sendBtn.disabled = true;
+  result.textContent = "";
+
+  const userNode = document.createElement("div");
+  userNode.className = "debug-chat-msg user";
+  userNode.innerHTML = `<div class="debug-chat-role">玩家</div><div>${markdownToHtml(text)}</div>`;
+  box.appendChild(userNode);
+
+  const gmNode = document.createElement("div");
+  gmNode.className = "debug-chat-msg assistant";
+  gmNode.innerHTML = `<div class="debug-chat-role">Debug GM</div><div class="debug-chat-stream"></div>`;
+  box.appendChild(gmNode);
+  box.scrollTop = box.scrollHeight;
+
+  let streamed = "";
+  try {
+    await streamFromSSE(
+      "/api/debug/chat/stream",
+      { branch_id: currentBranchId, user_message: text },
+      (chunk) => {
+        streamed += chunk;
+        const target = gmNode.querySelector(".debug-chat-stream");
+        if (target) target.innerHTML = markdownToHtml(streamed);
+        box.scrollTop = box.scrollHeight;
+      },
+      async (data) => {
+        const finalText = data.response || streamed;
+        const target = gmNode.querySelector(".debug-chat-stream");
+        if (target) target.innerHTML = markdownToHtml(finalText);
+        _debugPendingProposals = data.proposals || [];
+        _debugPendingDirectives = data.directives || [];
+        _renderDebugProposals();
+        await _loadDebugSession(false);
+      },
+      (errMsg) => {
+        gmNode.remove();
+        showAlert(errMsg || "debug chat 失敗");
+      },
+    );
+  } finally {
+    sendBtn.disabled = false;
+  }
+}
+
+async function applyDebugChanges() {
+  const result = document.getElementById("debug-apply-result");
+  if (!result) return;
+  try {
+    const actions = _collectDebugSelectedItems("action");
+    const directives = _collectDebugSelectedItems("directive");
+    const res = await API.debugApply(currentBranchId, actions, directives);
+    if (!res.ok) {
+      result.textContent = res.error || "套用失敗";
+      return;
+    }
+    const failed = (res.results || []).filter(x => !x.ok);
+    const failLines = failed.map(x => `- ${x.type}: ${x.error || "unknown error"}`);
+    result.textContent = [res.audit_summary || "", ...failLines].filter(Boolean).join("\n");
+    await loadMessages(currentBranchId);
+    await _loadDebugSession();
+  } catch (e) {
+    result.textContent = e.message || "套用失敗";
+  }
+}
+
+async function undoDebugChanges() {
+  const result = document.getElementById("debug-apply-result");
+  if (!result) return;
+  const res = await API.debugUndo(currentBranchId);
+  if (!res.ok) {
+    result.textContent = res.error || "Undo 失敗";
+    return;
+  }
+  result.textContent = res.audit_summary || "已回滾";
+  await loadMessages(currentBranchId);
+  await _loadDebugSession();
 }
 
 async function loadAddonPanelState() {
@@ -3932,6 +4218,11 @@ function appendMessage(msg) {
     }
   }
 
+  if (msg.message_type === "debug_audit") {
+    $messages.appendChild(createDebugAuditMessageElement(msg));
+    return;
+  }
+
   const el = document.createElement("div");
   el.className = `message ${msg.role}`;
   if (msg.inherited) el.classList.add("inherited");
@@ -4216,6 +4507,11 @@ document.addEventListener("keydown", (e) => {
     if (!document.getElementById("pistol-prefs-modal").classList.contains("hidden")) {
       e.stopImmediatePropagation();
       closePistolPrefsModal();
+      return;
+    }
+    if (!document.getElementById("debug-panel-modal").classList.contains("hidden")) {
+      e.stopImmediatePropagation();
+      closeDebugPanel();
       return;
     }
     if (!document.getElementById("addon-panel").classList.contains("hidden")) {

--- a/static/app.js
+++ b/static/app.js
@@ -4537,66 +4537,113 @@ function _renderDebugChatMessages(messages) {
   box.scrollTop = box.scrollHeight;
 }
 
-function _updateDebugApplyButton() {
-  const btn = document.getElementById("debug-apply-btn");
-  if (!btn) return;
+function _renderInlineProposalCards(container) {
   const count = _debugPendingProposals.length + _debugPendingDirectives.length;
-  if (count > 0) {
-    btn.textContent = `套用修正 (${count} 筆)`;
-    btn.classList.add("pulse-ready");
-    btn.disabled = false;
-  } else {
-    btn.textContent = "目前無待套用修正";
-    btn.classList.remove("pulse-ready");
-    btn.disabled = true;
-  }
-  _renderDebugPendingOptions();
-}
+  if (count === 0) return;
 
-function _renderDebugPendingOptions() {
-  const container = document.getElementById("debug-pending-options-container");
-  if (!container) return;
-
-  const count = _debugPendingProposals.length + _debugPendingDirectives.length;
-  if (count === 0) {
-    container.classList.add("hidden");
-    container.innerHTML = "";
-    return;
-  }
-
-  let html = `<div class="debug-options-header">準備套用的修正列表 (${count})：</div>`;
+  const cardsContainer = document.createElement("div");
+  cardsContainer.className = "proposal-cards";
 
   _debugPendingProposals.forEach((p, i) => {
-    let text = "";
-    if (p.type === "state_patch") text = `狀態修改: ${JSON.stringify(p.update)}`;
-    else if (p.type === "npc_upsert") text = `新增/覆寫 NPC: ${(p.npc && (p.npc.name || p.npc.id)) || '未命名'}`;
-    else if (p.type === "npc_delete") text = `刪除 NPC: ${p.npc_id}`;
-    else if (p.type === "world_day_set") text = `修改天數為: ${p.day || p.world_day}`;
-    else if (p.type === "dungeon_patch") text = `副本進度: ${JSON.stringify(p.update)}`;
-    else text = `其他修改: ${p.type}`;
+    let badgeClass = "edit";
+    let badgeText = "狀態";
+    let topic = p.type;
+    let contentHtml = "";
 
-    html += `
-      <label class="debug-option-item">
-        <input type="checkbox" class="debug-prop-cb" data-index="${i}" checked>
-        <span>${escapeHtml(text)}</span>
-      </label>
+    if (p.type === "state_patch") {
+      const key = Object.keys(p.update)[0];
+      const val = p.update[key];
+      topic = key;
+      contentHtml = `數值調整為: ${JSON.stringify(val)}`;
+    } else if (p.type === "npc_upsert") {
+      badgeClass = "add"; badgeText = "NPC";
+      topic = (p.npc && (p.npc.name || p.npc.id)) || '未命名';
+      contentHtml = `覆寫設定: ${JSON.stringify(p.npc)}`;
+    } else if (p.type === "npc_delete") {
+      badgeClass = "delete"; badgeText = "刪除 NPC";
+      topic = p.npc_id;
+      contentHtml = `刪除此 NPC`;
+    } else if (p.type === "world_day_set") {
+      badgeClass = "edit"; badgeText = "系統";
+      topic = "推進天數";
+      contentHtml = `修改為: ${p.day || p.world_day}`;
+    } else if (p.type === "dungeon_patch") {
+      badgeClass = "edit"; badgeText = "副本";
+      topic = "推進進度";
+      contentHtml = `變更為: ${JSON.stringify(p.update)}`;
+    }
+
+    const card = document.createElement("div");
+    card.className = "proposal-card";
+    card.innerHTML = `
+      <div class="proposal-header">
+        <span class="proposal-badge ${badgeClass}">${escapeHtml(badgeText)}</span>
+        <span class="proposal-topic">${escapeHtml(topic)}</span>
+      </div>
+      <div class="proposal-content">${escapeHtml(contentHtml)}</div>
+      <div class="proposal-actions">
+        <button class="btn-accept" onclick="applySingleDebugAction('proposal', ${i}, this)">採用</button>
+        <button class="btn-reject" onclick="rejectSingleDebugAction(this)">忽略</button>
+      </div>
     `;
+    cardsContainer.appendChild(card);
   });
 
   _debugPendingDirectives.forEach((d, i) => {
     const text = d.instruction || "";
-    const shortText = text.length > 60 ? text.substring(0, 60) + "..." : text;
-    html += `
-      <label class="debug-option-item directive">
-        <input type="checkbox" class="debug-dir-cb" data-index="${i}" checked>
-        <span title="${escapeHtml(text)}">寫入劇情設定: ${escapeHtml(shortText)}</span>
-      </label>
+    const card = document.createElement("div");
+    card.className = "proposal-card";
+    card.innerHTML = `
+      <div class="proposal-header">
+        <span class="proposal-badge add">劇情</span>
+        <span class="proposal-topic">寫入設定</span>
+      </div>
+      <div class="proposal-content">${escapeHtml(text)}</div>
+      <div class="proposal-actions">
+        <button class="btn-accept" onclick="applySingleDebugAction('directive', ${i}, this)">採用</button>
+        <button class="btn-reject" onclick="rejectSingleDebugAction(this)">忽略</button>
+      </div>
     `;
+    cardsContainer.appendChild(card);
   });
 
-  container.innerHTML = html;
-  container.classList.remove("hidden");
+  container.appendChild(cardsContainer);
 }
+
+window.applySingleDebugAction = async function (type, index, btn) {
+  const card = btn.closest(".proposal-card");
+  btn.disabled = true;
+  const originalText = btn.textContent;
+  btn.textContent = "套用中...";
+
+  let pList = [];
+  let dList = [];
+  if (type === 'proposal') {
+    pList.push(_debugPendingProposals[index]);
+  } else {
+    dList.push(_debugPendingDirectives[index]);
+  }
+
+  try {
+    const res = await API.debugApply(currentBranchId, pList, dList);
+    if (!res.ok) throw new Error(res.error);
+
+    card.classList.add("applied");
+    card.querySelector(".proposal-actions").innerHTML = `<span style="color:#4caf50;font-size:0.85em;font-weight:bold;">✔ 已採用</span>`;
+    showAlert(res.audit_summary || "變更套用成功！");
+    await loadMessages(currentBranchId);
+  } catch (e) {
+    showAlert("套用失敗: " + e.message);
+    btn.disabled = false;
+    btn.textContent = originalText;
+  }
+};
+
+window.rejectSingleDebugAction = function (btn) {
+  const card = btn.closest(".proposal-card");
+  card.classList.add("rejected");
+  card.querySelector(".proposal-actions").innerHTML = `<span style="color:#888;font-size:0.85em;font-weight:bold;">❌ 已忽略</span>`;
+};
 
 async function _loadDebugSession(resetSuggestions = true) {
   const res = await API.debugSession(currentBranchId);
@@ -4609,7 +4656,6 @@ async function _loadDebugSession(resetSuggestions = true) {
     _debugPendingProposals = [];
     _debugPendingDirectives = [];
   }
-  _updateDebugApplyButton();
 }
 
 async function openDebugPanel() {
@@ -4679,55 +4725,36 @@ async function sendDebugChat() {
           }
           target.innerHTML = markdownToHtml(stripDebugTags(finalText));
         }
-        _debugPendingProposals = data.proposals || [];
+
+        const rawProposals = data.proposals || [];
+        const splitProposals = [];
+        rawProposals.forEach(p => {
+          if (p.type === "state_patch" && typeof p.update === "object") {
+            for (const [key, value] of Object.entries(p.update)) {
+              splitProposals.push({ type: "state_patch", update: { [key]: value } });
+            }
+          } else {
+            splitProposals.push(p);
+          }
+        });
+
+        _debugPendingProposals = splitProposals;
         _debugPendingDirectives = data.directives || [];
-        await _loadDebugSession(false);
+
+        if (target) {
+          _renderInlineProposalCards(target);
+        }
       },
       (errMsg) => {
         gmNode.remove();
         showAlert(errMsg || "debug chat 失敗");
-      },
+      }
     );
   } finally {
     sendBtn.disabled = false;
   }
 }
 
-async function applyDebugChanges() {
-  const result = document.getElementById("debug-apply-result");
-  if (!result) return;
-
-  const selectedProposals = [];
-  document.querySelectorAll(".debug-prop-cb:checked").forEach(cb => {
-    selectedProposals.push(_debugPendingProposals[parseInt(cb.dataset.index, 10)]);
-  });
-  const selectedDirectives = [];
-  document.querySelectorAll(".debug-dir-cb:checked").forEach(cb => {
-    selectedDirectives.push(_debugPendingDirectives[parseInt(cb.dataset.index, 10)]);
-  });
-
-  const total = selectedProposals.length + selectedDirectives.length;
-  if (total === 0) {
-    showAlert("請至少選擇一項修正！");
-    return;
-  }
-
-  try {
-    const res = await API.debugApply(currentBranchId, selectedProposals, selectedDirectives);
-    if (!res.ok) {
-      result.textContent = res.error || "套用失敗";
-      return;
-    }
-    const failed = (res.results || []).filter(x => !x.ok);
-    const failLines = failed.map(x => `- ${x.type}: ${x.error || "unknown error"}`);
-    result.textContent = [res.audit_summary || "", ...failLines].filter(Boolean).join("\n");
-    showAlert(res.audit_summary || `變更套用成功！已套用 ${total} 筆修正`);
-    await loadMessages(currentBranchId);
-    await _loadDebugSession();
-  } catch (e) {
-    result.textContent = e.message || "套用失敗";
-  }
-}
 
 async function undoDebugChanges() {
   const result = document.getElementById("debug-apply-result");

--- a/static/app.js
+++ b/static/app.js
@@ -4509,12 +4509,46 @@ init();
 // Debug Panel Layout
 // ==========================================
 
+function _parseDebugContent(text) {
+  if (!text) return { cleanText: "", proposals: [], directives: [] };
+  const proposals = [];
+  const directives = [];
+
+  // Extract actions
+  let cleanText = text.replace(/<!--DEBUG_ACTION\s+([\s\S]*?)\s+DEBUG_ACTION-->/g, (match, jsonStr) => {
+    try {
+      const p = JSON.parse(jsonStr);
+      if (p.type === "state_patch" && typeof p.update === "object") {
+        for (const [key, value] of Object.entries(p.update)) {
+          proposals.push({ type: "state_patch", update: { [key]: value } });
+        }
+      } else {
+        proposals.push(p);
+      }
+    } catch (e) {
+      console.warn("Failed to parse debug action:", e);
+    }
+    return "";
+  });
+
+  // Extract directives
+  cleanText = cleanText.replace(/<!--DEBUG_DIRECTIVE\s+([\s\S]*?)\s+DEBUG_DIRECTIVE-->/g, (match, jsonStr) => {
+    try {
+      const d = JSON.parse(jsonStr);
+      if (d.instruction) {
+        directives.push({ instruction: d.instruction.trim() });
+      }
+    } catch (e) {
+      console.warn("Failed to parse debug directive:", e);
+    }
+    return "";
+  });
+
+  return { cleanText: cleanText.trim(), proposals, directives };
+}
+
 function stripDebugTags(text) {
-  if (!text) return "";
-  return text
-    .replace(/<!--DEBUG_ACTION[\s\S]*?DEBUG_ACTION-->/g, "")
-    .replace(/<!--DEBUG_DIRECTIVE[\s\S]*?DEBUG_DIRECTIVE-->/g, "")
-    .trim();
+  return _parseDebugContent(text).cleanText;
 }
 
 function _renderDebugChatMessages(messages) {
@@ -4528,23 +4562,33 @@ function _renderDebugChatMessages(messages) {
     role.className = "debug-chat-role";
     role.textContent = msg.role === "user" ? "玩家" : "Debug GM";
     const content = document.createElement("div");
-    const cleanContent = msg.role === "assistant" ? stripDebugTags(msg.content) : msg.content;
-    content.innerHTML = markdownToHtml(cleanContent || "");
-    node.appendChild(role);
-    node.appendChild(content);
+
+    if (msg.role === "assistant") {
+      const parsed = _parseDebugContent(msg.content);
+      content.innerHTML = markdownToHtml(parsed.cleanText || "");
+      node.appendChild(role);
+      node.appendChild(content);
+      _renderInlineProposalCards(node, parsed.proposals, parsed.directives);
+    } else {
+      content.innerHTML = markdownToHtml(msg.content || "");
+      node.appendChild(role);
+      node.appendChild(content);
+    }
     box.appendChild(node);
   }
   box.scrollTop = box.scrollHeight;
 }
 
-function _renderInlineProposalCards(container) {
-  const count = _debugPendingProposals.length + _debugPendingDirectives.length;
+function _renderInlineProposalCards(container, proposals, directives) {
+  proposals = proposals || _debugPendingProposals;
+  directives = directives || _debugPendingDirectives;
+  const count = proposals.length + directives.length;
   if (count === 0) return;
 
   const cardsContainer = document.createElement("div");
   cardsContainer.className = "proposal-cards";
 
-  _debugPendingProposals.forEach((p, i) => {
+  proposals.forEach((p, i) => {
     let badgeClass = "edit";
     let badgeText = "狀態";
     let topic = p.type;
@@ -4575,6 +4619,7 @@ function _renderInlineProposalCards(container) {
 
     const card = document.createElement("div");
     card.className = "proposal-card";
+    const dataPayload = encodeURIComponent(JSON.stringify(p));
     card.innerHTML = `
       <div class="proposal-header">
         <span class="proposal-badge ${badgeClass}">${escapeHtml(badgeText)}</span>
@@ -4582,15 +4627,16 @@ function _renderInlineProposalCards(container) {
       </div>
       <div class="proposal-content">${escapeHtml(contentHtml)}</div>
       <div class="proposal-actions">
-        <button class="btn-accept" onclick="applySingleDebugAction('proposal', ${i}, this)">採用</button>
+        <button class="btn-accept" onclick="applySingleDebugAction('proposal', '${dataPayload}', this)">採用</button>
         <button class="btn-reject" onclick="rejectSingleDebugAction(this)">忽略</button>
       </div>
     `;
     cardsContainer.appendChild(card);
   });
 
-  _debugPendingDirectives.forEach((d, i) => {
+  directives.forEach((d, i) => {
     const text = (d.instruction || "").trim();
+    const dataPayload = encodeURIComponent(JSON.stringify(d));
     const card = document.createElement("div");
     card.className = "proposal-card";
     card.innerHTML = `
@@ -4600,7 +4646,7 @@ function _renderInlineProposalCards(container) {
       </div>
       <div class="proposal-content">${escapeHtml(text)}</div>
       <div class="proposal-actions">
-        <button class="btn-accept" onclick="applySingleDebugAction('directive', ${i}, this)">採用</button>
+        <button class="btn-accept" onclick="applySingleDebugAction('directive', '${dataPayload}', this)">採用</button>
         <button class="btn-reject" onclick="rejectSingleDebugAction(this)">忽略</button>
       </div>
     `;
@@ -4610,7 +4656,7 @@ function _renderInlineProposalCards(container) {
   container.appendChild(cardsContainer);
 }
 
-window.applySingleDebugAction = async function (type, index, btn) {
+window.applySingleDebugAction = async function (type, payloadStr, btn) {
   const card = btn.closest(".proposal-card");
   btn.disabled = true;
   const originalText = btn.textContent;
@@ -4618,13 +4664,14 @@ window.applySingleDebugAction = async function (type, index, btn) {
 
   let pList = [];
   let dList = [];
-  if (type === 'proposal') {
-    pList.push(_debugPendingProposals[index]);
-  } else {
-    dList.push(_debugPendingDirectives[index]);
-  }
-
   try {
+    const payload = JSON.parse(decodeURIComponent(payloadStr));
+    if (type === 'proposal') {
+      pList.push(payload);
+    } else {
+      dList.push(payload);
+    }
+
     const res = await API.debugApply(currentBranchId, pList, dList);
     if (!res.ok) throw new Error(res.error);
 
@@ -4740,8 +4787,8 @@ async function sendDebugChat() {
         _debugPendingProposals = splitProposals;
         _debugPendingDirectives = data.directives || [];
 
-        if (target) {
-          _renderInlineProposalCards(target);
+        if (gmNode) {
+          _renderInlineProposalCards(gmNode, splitProposals, data.directives || []);
         }
       },
       (errMsg) => {

--- a/static/style.css
+++ b/static/style.css
@@ -1676,7 +1676,7 @@ body {
 .debug-chat-messages {
   flex: 1;
   min-height: 200px;
-  max-height: 40vh;
+  max-height: 75vh;
   overflow-y: auto;
   border: 1px solid var(--border);
   border-radius: var(--radius);
@@ -1775,7 +1775,7 @@ body {
 #debug-chat-input {
   flex: 1;
   min-height: 80px;
-  max-height: 180px;
+  max-height: 300px;
   resize: vertical;
   padding: 8px 10px;
   border: 1px solid var(--border);

--- a/static/style.css
+++ b/static/style.css
@@ -1399,43 +1399,104 @@ body {
   margin-top: 5px;
 }
 
-.debug-pending-options-container {
-  margin: 10px 0;
-  padding: 12px;
-  background: var(--bg-tertiary);
-  border: 1px solid var(--border-color);
-  border-radius: var(--radius);
-}
-
-.debug-options-header {
-  font-size: 0.9em;
-  font-weight: 600;
-  color: var(--text-color);
-  margin-bottom: 10px;
-}
-
-.debug-option-item {
+/* Proposal cards in chat */
+.proposal-cards {
+  margin-top: 10px;
   display: flex;
-  align-items: flex-start;
-  gap: 10px;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.proposal-card {
+  background: var(--bg-sidebar);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 10px 12px;
+}
+
+.proposal-card.applied {
+  opacity: 0.5;
+  border-color: #4a7c59;
+}
+
+.proposal-card.rejected {
+  opacity: 0.4;
+}
+
+.proposal-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.proposal-badge {
+  font-size: 0.75rem;
+  font-weight: 700;
+  padding: 1px 6px;
+  border-radius: 4px;
+}
+
+.proposal-badge.add {
+  background: #2d5a3a;
+  color: #7fdb96;
+}
+
+.proposal-badge.edit {
+  background: #5a4a2d;
+  color: #dbc37f;
+}
+
+.proposal-badge.delete {
+  background: #5a2d2d;
+  color: #db7f7f;
+}
+
+.proposal-topic {
+  font-weight: 600;
+  font-size: 0.88rem;
+}
+
+.proposal-content {
+  font-size: 0.82rem;
+  color: var(--text-dim);
+  max-height: 200px;
+  overflow-y: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
   margin-bottom: 8px;
-  font-size: 0.9em;
-  color: var(--text-color);
+}
+
+.proposal-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.proposal-actions button {
+  padding: 4px 14px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: none;
+  color: var(--text);
+  font-size: 0.8rem;
   cursor: pointer;
-  line-height: 1.4;
 }
 
-.debug-option-item:last-child {
-  margin-bottom: 0;
+.proposal-actions .btn-accept {
+  border-color: #4a7c59;
+  color: #7fdb96;
 }
 
-.debug-option-item input[type="checkbox"] {
-  margin-top: 3px;
-  cursor: pointer;
+.proposal-actions .btn-accept:hover {
+  background: #2d5a3a;
 }
 
-.debug-option-item.directive span {
-  color: #a5d6a7;
+.proposal-actions .btn-reject {
+  color: var(--text-dim);
+}
+
+.proposal-actions .btn-reject:hover {
+  background: var(--bg-user);
 }
 
 .debug-panel-tools .cheat-toggle:disabled {

--- a/static/style.css
+++ b/static/style.css
@@ -754,9 +754,26 @@ body {
 }
 
 /* ---------- Message Action Button ---------- */
-.msg-action-btn {
+
+.msg-actions {
   position: absolute;
   bottom: 8px;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  z-index: 10;
+}
+
+.message.gm .msg-actions {
+  left: 0;
+}
+
+.message.user .msg-actions {
+  right: 14px;
+  flex-direction: row-reverse;
+}
+
+.msg-action-btn {
   background: var(--bg-main);
   border: 1px solid var(--border);
   border-radius: 6px;
@@ -766,14 +783,6 @@ body {
   cursor: pointer;
   line-height: 1;
   transition: background 0.15s, color 0.15s, border-color 0.15s;
-}
-
-.message.gm .msg-action-btn {
-  left: 0;
-}
-
-.message.user .msg-action-btn {
-  right: 14px;
 }
 
 .msg-action-btn:hover {
@@ -1399,6 +1408,25 @@ body {
   margin-top: 5px;
 }
 
+.directive-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.directive-cancel-btn {
+  font-size: 1.2rem;
+  color: var(--text-dim);
+  cursor: pointer;
+  line-height: 1;
+  transition: color 0.2s;
+  padding: 4px;
+}
+
+.directive-cancel-btn:hover {
+  color: #ff5252;
+}
+
 /* Proposal cards in chat */
 .proposal-cards {
   margin-top: 10px;
@@ -1464,7 +1492,7 @@ body {
   max-height: 200px;
   overflow-y: auto;
   white-space: pre-wrap;
-  word-break: break-word;
+  word-break: break-all;
   margin-bottom: 8px;
 }
 
@@ -1671,6 +1699,67 @@ body {
   color: var(--text-dim);
   font-size: 0.8rem;
   margin-bottom: 10px;
+}
+
+
+.debug-pending-directive-container {
+  background: rgba(212, 175, 55, 0.08);
+  border: 1px dashed var(--gold);
+  border-left: 3px solid var(--gold);
+  border-radius: var(--radius);
+  margin-bottom: 12px;
+  overflow: hidden;
+  transition: all 0.3s ease;
+}
+
+.debug-pending-directive-container.hidden {
+  display: none;
+}
+
+.debug-pending-directive-header {
+  padding: 8px 12px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  cursor: pointer;
+  user-select: none;
+}
+
+.debug-pending-directive-header:hover {
+  background: rgba(212, 175, 55, 0.12);
+}
+
+.directive-label {
+  font-size: 0.85rem;
+  font-weight: bold;
+  color: var(--gold);
+}
+
+.directive-toggle-icon {
+  font-size: 0.7rem;
+  color: var(--gold);
+  transition: transform 0.3s ease;
+}
+
+.debug-pending-directive-container.expanded .directive-toggle-icon {
+  transform: rotate(180deg);
+}
+
+.debug-pending-directive-content {
+  max-height: 0;
+  padding: 0 12px;
+  overflow-y: auto;
+  font-size: 0.82rem;
+  color: var(--text-main);
+  line-height: 1.5;
+  transition: max-height 0.3s ease, padding 0.3s ease;
+  word-break: break-all;
+}
+
+.debug-pending-directive-container.expanded .debug-pending-directive-content {
+  max-height: 150px;
+  padding: 0 12px 10px 12px;
+  border-top: 1px solid rgba(212, 175, 55, 0.2);
 }
 
 .debug-chat-messages {
@@ -3073,8 +3162,6 @@ body {
 
 /* ---------- Bug report button (#6) ---------- */
 .msg-report-btn {
-  position: absolute;
-  bottom: 8px;
   background: none;
   border: none;
   color: var(--text-dim);
@@ -3092,14 +3179,6 @@ body {
 .msg-report-btn:hover {
   opacity: 1 !important;
   color: var(--accent);
-}
-
-.message.gm .msg-report-btn {
-  left: 52px;
-}
-
-.message.user .msg-report-btn {
-  right: 56px;
 }
 
 .report-modal-overlay {
@@ -3249,6 +3328,18 @@ body {
   border-radius: var(--radius);
   padding: 10px 12px;
   margin-bottom: 10px;
+}
+
+.dungeon-overview.preparation-mode {
+  border-left: 3px solid var(--gold);
+  background: rgba(212, 175, 55, 0.05);
+}
+
+.dungeon-prep-hint {
+  font-size: 0.75rem;
+  color: var(--text-dim);
+  margin-top: 8px;
+  font-style: italic;
 }
 
 /* Mainline progress bar */

--- a/static/style.css
+++ b/static/style.css
@@ -573,12 +573,29 @@ body {
   text-align: left;
 }
 
+.message.debug-audit {
+  background: rgba(184, 134, 11, 0.08);
+  border: 1px dashed rgba(184, 134, 11, 0.45);
+  border-radius: 10px;
+  margin: 10px auto;
+  max-width: 52em;
+  padding: 10px 12px;
+}
+
 .message.inherited {
   opacity: 1;
 }
 
 .message .role-tag {
   display: none;
+}
+
+.message.debug-audit .role-tag {
+  display: inline-block;
+  color: var(--gold);
+  font-size: 0.76rem;
+  font-weight: 700;
+  margin-bottom: 4px;
 }
 
 .message .content h1,
@@ -1393,6 +1410,147 @@ body {
 }
 .prompt-modal-input:focus {
   border-color: var(--gold);
+}
+
+/* ---------- Debug Panel Modal ---------- */
+.debug-panel-content {
+  max-width: 860px;
+  width: 95%;
+}
+
+.debug-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.debug-panel-header h2 {
+  margin: 0;
+}
+
+.debug-panel-meta {
+  display: flex;
+  gap: 14px;
+  color: var(--text-dim);
+  font-size: 0.8rem;
+  margin-bottom: 10px;
+}
+
+.debug-chat-messages {
+  max-height: 34vh;
+  overflow-y: auto;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 10px;
+  background: rgba(0, 0, 0, 0.1);
+  margin-bottom: 10px;
+}
+
+.debug-chat-msg {
+  margin-bottom: 8px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: 0.88rem;
+}
+
+.debug-chat-msg.user {
+  background: rgba(62, 122, 77, 0.2);
+  border-color: rgba(62, 122, 77, 0.45);
+}
+
+.debug-chat-msg.assistant {
+  background: rgba(184, 134, 11, 0.12);
+  border-color: rgba(184, 134, 11, 0.35);
+}
+
+.debug-chat-msg .debug-chat-role {
+  font-size: 0.76rem;
+  color: var(--text-dim);
+  margin-bottom: 4px;
+}
+
+.debug-chat-input-row {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+#debug-chat-input {
+  flex: 1;
+  min-height: 60px;
+  max-height: 140px;
+  resize: vertical;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--input-bg);
+  color: var(--text);
+  font-size: 0.9rem;
+  font-family: inherit;
+}
+
+#debug-chat-send {
+  align-self: flex-end;
+}
+
+.debug-block {
+  margin-bottom: 12px;
+}
+
+.debug-block-title {
+  font-size: 0.82rem;
+  color: var(--text-dim);
+  margin-bottom: 6px;
+}
+
+.debug-items {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.debug-item {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 8px;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.debug-item-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.82rem;
+  margin-bottom: 6px;
+}
+
+.debug-item-json {
+  width: 100%;
+  min-height: 72px;
+  resize: vertical;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--input-bg);
+  color: var(--text);
+  font-size: 0.82rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+  padding: 8px;
+}
+
+.debug-panel-actions {
+  display: flex;
+  gap: 10px;
+}
+
+.debug-apply-result {
+  margin-top: 10px;
+  font-size: 0.85rem;
+  color: var(--text-dim);
+  white-space: pre-wrap;
 }
 
 /* ---------- Init loading overlay ---------- */
@@ -2240,6 +2398,20 @@ body {
     right: 20px;
     left: 20px;
     width: auto;
+  }
+
+  .debug-panel-content {
+    width: 95%;
+    max-height: 92vh;
+    padding: 16px;
+  }
+
+  .debug-chat-input-row {
+    flex-direction: column;
+  }
+
+  #debug-chat-send {
+    width: 100%;
   }
 
   /* Branch tree: always show action buttons on mobile (no hover) */

--- a/static/style.css
+++ b/static/style.css
@@ -1690,7 +1690,6 @@ body {
   padding: 8px 10px;
   border-radius: 8px;
   border: 1px solid transparent;
-  white-space: pre-wrap;
   word-break: break-word;
   font-size: 0.88rem;
 }

--- a/static/style.css
+++ b/static/style.css
@@ -1399,6 +1399,45 @@ body {
   margin-top: 5px;
 }
 
+.debug-pending-options-container {
+  margin: 10px 0;
+  padding: 12px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius);
+}
+
+.debug-options-header {
+  font-size: 0.9em;
+  font-weight: 600;
+  color: var(--text-color);
+  margin-bottom: 10px;
+}
+
+.debug-option-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  margin-bottom: 8px;
+  font-size: 0.9em;
+  color: var(--text-color);
+  cursor: pointer;
+  line-height: 1.4;
+}
+
+.debug-option-item:last-child {
+  margin-bottom: 0;
+}
+
+.debug-option-item input[type="checkbox"] {
+  margin-top: 3px;
+  cursor: pointer;
+}
+
+.debug-option-item.directive span {
+  color: #a5d6a7;
+}
+
 .debug-panel-tools .cheat-toggle:disabled {
   background: var(--bg-tertiary);
   color: var(--text-muted);

--- a/static/style.css
+++ b/static/style.css
@@ -1392,6 +1392,51 @@ body {
   min-height: 60px;
 }
 
+.debug-panel-tools {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  margin-top: 5px;
+}
+
+.debug-panel-tools .cheat-toggle:disabled {
+  background: var(--bg-tertiary);
+  color: var(--text-muted);
+  border-color: var(--border-color);
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+}
+
+@keyframes pulseReady {
+  0% {
+    box-shadow: 0 0 0 0 rgba(76, 175, 80, 0.4);
+  }
+
+  70% {
+    box-shadow: 0 0 0 6px rgba(76, 175, 80, 0);
+  }
+
+  100% {
+    box-shadow: 0 0 0 0 rgba(76, 175, 80, 0);
+  }
+}
+
+.debug-panel-tools .cheat-toggle.pulse-ready {
+  background: #4caf50;
+  color: #fff;
+  border-color: #4caf50;
+  animation: pulseReady 2s infinite;
+}
+
+.debug-result-text {
+  padding: 8px 20px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: transparent;
+  color: var(--text-dim);
+}
+
 .modal-actions {
   display: flex;
   gap: 10px;

--- a/static/style.css
+++ b/static/style.css
@@ -1710,6 +1710,30 @@ body {
   margin-bottom: 4px;
 }
 
+.debug-chat-msg p {
+  margin: 8px 0;
+}
+
+.debug-chat-msg h1,
+.debug-chat-msg h2,
+.debug-chat-msg h3,
+.debug-chat-msg h4 {
+  margin: 12px 0 6px;
+  font-size: 0.95rem;
+}
+
+.debug-chat-msg blockquote {
+  margin: 8px 0;
+  padding-left: 10px;
+  border-left: 3px solid var(--border);
+  color: var(--text-dim);
+}
+
+.debug-chat-msg pre {
+  margin: 8px 0;
+  white-space: pre-wrap;
+}
+
 .debug-chat-msg ul,
 .debug-chat-msg ol {
   padding-left: 24px;

--- a/static/style.css
+++ b/static/style.css
@@ -1412,6 +1412,7 @@ body {
   border: 1px solid var(--border);
   border-radius: var(--radius);
   padding: 10px 12px;
+  white-space: normal;
 }
 
 .proposal-card.applied {

--- a/static/style.css
+++ b/static/style.css
@@ -1632,9 +1632,9 @@ body {
 
 /* ---------- Debug Panel Modal ---------- */
 .debug-panel-content {
-  max-width: 860px;
+  max-width: 1080px;
   width: 95%;
-  max-height: 90vh;
+  max-height: 92vh;
   /* Allow it to be taller than default */
   display: flex;
   flex-direction: column;

--- a/static/style.css
+++ b/static/style.css
@@ -1634,7 +1634,7 @@ body {
 .debug-panel-content {
   max-width: 1080px;
   width: 95%;
-  max-height: 92vh;
+  max-height: 96vh;
   /* Allow it to be taller than default */
   display: flex;
   flex-direction: column;

--- a/static/style.css
+++ b/static/style.css
@@ -1710,6 +1710,17 @@ body {
   margin-bottom: 4px;
 }
 
+.debug-chat-msg ul,
+.debug-chat-msg ol {
+  padding-left: 24px;
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+.debug-chat-msg li {
+  margin-bottom: 4px;
+}
+
 .debug-thinking {
   font-style: italic;
   color: var(--text-dim);

--- a/static/style.css
+++ b/static/style.css
@@ -1634,7 +1634,7 @@ body {
 .debug-panel-content {
   max-width: 1080px;
   width: 95%;
-  max-height: 96vh;
+  height: 96vh;
   /* Allow it to be taller than default */
   display: flex;
   flex-direction: column;

--- a/static/style.css
+++ b/static/style.css
@@ -124,6 +124,7 @@ body {
   border-radius: 6px;
   opacity: 0.7;
 }
+
 .header-lore-link:hover {
   opacity: 1;
   background: var(--bg-user);
@@ -141,9 +142,17 @@ body {
   background: rgba(255, 68, 68, 0.1);
   animation: live-pulse 1.5s ease-in-out infinite;
 }
+
 @keyframes live-pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.5; }
+
+  0%,
+  100% {
+    opacity: 1;
+  }
+
+  50% {
+    opacity: 0.5;
+  }
 }
 
 .incomplete-banner {
@@ -158,10 +167,12 @@ body {
   border-radius: 8px;
   text-align: center;
 }
+
 .incomplete-banner-text {
   color: #ffaa00;
   font-size: 0.9rem;
 }
+
 .incomplete-banner-btn {
   padding: 6px 16px;
   border: 1px solid rgba(255, 170, 0, 0.4);
@@ -171,6 +182,7 @@ body {
   cursor: pointer;
   font-size: 0.85rem;
 }
+
 .incomplete-banner-btn:hover {
   background: rgba(255, 170, 0, 0.25);
 }
@@ -341,9 +353,20 @@ body {
   border-radius: 4px;
   transition: opacity 0.15s, color 0.15s;
 }
-.drawer-item:hover .drawer-item-action { opacity: 1; }
-.drawer-item-action:hover { color: #b8860b; background: rgba(184, 134, 11, 0.1); }
-.drawer-item-action-del:hover { color: var(--accent); background: rgba(217, 48, 37, 0.1); }
+
+.drawer-item:hover .drawer-item-action {
+  opacity: 1;
+}
+
+.drawer-item-action:hover {
+  color: #b8860b;
+  background: rgba(184, 134, 11, 0.1);
+}
+
+.drawer-item-action-del:hover {
+  color: var(--accent);
+  background: rgba(217, 48, 37, 0.1);
+}
 
 .branch-id-tag {
   width: 100%;
@@ -368,7 +391,10 @@ body {
   border-top: 1px solid var(--border);
   margin-top: 4px;
 }
-.auto-play-section-header:hover { color: var(--text); }
+
+.auto-play-section-header:hover {
+  color: var(--text);
+}
 
 .branch-toggle-arrow {
   display: inline-block;
@@ -378,7 +404,10 @@ body {
   transition: transform 0.2s;
   flex-shrink: 0;
 }
-.branch-toggle-arrow.expanded { transform: rotate(90deg); }
+
+.branch-toggle-arrow.expanded {
+  transform: rotate(90deg);
+}
 
 .branch-group-children {
   overflow: hidden;
@@ -386,7 +415,11 @@ body {
   max-height: 5000px;
   opacity: 1;
 }
-.branch-group-children.collapsed { max-height: 0; opacity: 0; }
+
+.branch-group-children.collapsed {
+  max-height: 0;
+  opacity: 0;
+}
 
 .auto-branch-badge {
   padding: 1px 6px;
@@ -710,9 +743,11 @@ body {
   opacity: 0;
   transition: opacity 0.2s, color 0.2s;
 }
+
 .sibling-switcher:hover .sw-delete {
   opacity: 0.6;
 }
+
 .sw-delete:hover {
   opacity: 1 !important;
   color: var(--accent);
@@ -998,15 +1033,18 @@ body {
   margin-left: 8px;
   transition: background 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s;
 }
+
 #addon-panel-btn:hover {
   background: rgba(255, 255, 255, 0.05);
   color: var(--text);
   border-color: var(--text-dim);
 }
+
 #addon-panel-btn:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
+
 #addon-panel-btn.addon-active {
   border-color: #4a8;
   color: #6fc;
@@ -1027,16 +1065,20 @@ body {
   padding: 0;
   overflow: hidden;
 }
+
 .addon-panel.hidden {
   display: none;
 }
+
 .addon-section {
   padding: 12px 16px;
   border-bottom: 1px solid var(--border);
 }
+
 .addon-section:last-child {
   border-bottom: none;
 }
+
 .addon-section-title {
   font-size: 0.78rem;
   font-weight: 700;
@@ -1045,15 +1087,18 @@ body {
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
+
 .addon-field {
   margin-bottom: 8px;
 }
+
 .addon-field label {
   display: block;
   font-size: 0.78rem;
   color: var(--text-dim);
   margin-bottom: 4px;
 }
+
 .addon-field select {
   width: 100%;
   padding: 6px 10px;
@@ -1072,10 +1117,12 @@ body {
   background-position: right 8px center;
   padding-right: 28px;
 }
+
 .addon-field select:hover,
 .addon-field select:focus {
   border-color: var(--gold);
 }
+
 .addon-field textarea {
   width: 100%;
   padding: 8px 10px;
@@ -1089,9 +1136,11 @@ body {
   resize: vertical;
   min-height: 50px;
 }
+
 .addon-field textarea:focus {
   border-color: var(--gold);
 }
+
 .addon-toggle-field {
   display: flex;
   align-items: center;
@@ -1100,6 +1149,7 @@ body {
   font-size: 0.84rem;
   color: var(--text);
 }
+
 .addon-save-btn {
   width: 100%;
   padding: 6px 0;
@@ -1112,11 +1162,13 @@ body {
   cursor: pointer;
   transition: background 0.15s, color 0.15s, border-color 0.15s;
 }
+
 .addon-save-btn:hover {
   background: rgba(255, 255, 255, 0.05);
   color: var(--text);
   border-color: var(--text-dim);
 }
+
 .addon-save-btn.saved {
   border-color: #4a8;
   color: #6fc;
@@ -1129,6 +1181,7 @@ body {
   align-items: center;
   gap: 6px;
 }
+
 .pistol-prefs-btn {
   width: 28px;
   height: 28px;
@@ -1143,14 +1196,17 @@ body {
   justify-content: center;
   transition: background 0.15s, color 0.15s;
 }
+
 .pistol-prefs-btn:hover {
   background: rgba(255, 255, 255, 0.08);
   color: var(--text);
 }
+
 .pistol-prefs-modal-content {
   max-width: 380px;
   width: 90vw;
 }
+
 .pistol-prefs-header {
   display: flex;
   align-items: center;
@@ -1159,10 +1215,12 @@ body {
   border-bottom: 1px solid var(--border);
   margin-bottom: 12px;
 }
+
 .pistol-prefs-header h2 {
   margin: 0;
   font-size: 1.05rem;
 }
+
 .pistol-prefs-body {
   display: flex;
   flex-direction: column;
@@ -1170,21 +1228,25 @@ body {
   max-height: 60vh;
   overflow-y: auto;
 }
+
 .pistol-chips-group {
   display: flex;
   flex-direction: column;
   gap: 6px;
 }
+
 .pistol-chips-label {
   font-size: 0.78rem;
   color: var(--text-dim);
   font-weight: 600;
 }
+
 .pistol-chips {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
 }
+
 .pistol-chip {
   padding: 5px 8px 5px 12px;
   border: 1px solid var(--border);
@@ -1200,24 +1262,29 @@ body {
   align-items: center;
   gap: 4px;
 }
+
 .pistol-chip:hover {
   background: rgba(255, 255, 255, 0.06);
   color: var(--text);
 }
+
 .pistol-chip.selected {
   background: rgba(255, 130, 170, 0.2);
   border-color: #f8a;
   color: #fcc;
 }
+
 .pistol-chip .chip-delete {
   font-size: 0.7rem;
   opacity: 0.5;
   cursor: pointer;
   margin-left: 2px;
 }
+
 .pistol-chip .chip-delete:hover {
   opacity: 1;
 }
+
 .pistol-chip-add {
   width: 30px;
   height: 30px;
@@ -1233,11 +1300,13 @@ body {
   transition: background 0.15s, color 0.15s, border-color 0.15s;
   flex-shrink: 0;
 }
+
 .pistol-chip-add:hover {
   background: rgba(255, 255, 255, 0.06);
   color: var(--text);
   border-color: var(--text-dim);
 }
+
 #pistol-custom-prefs {
   width: 100%;
   padding: 8px;
@@ -1249,6 +1318,7 @@ body {
   resize: vertical;
   font-family: inherit;
 }
+
 #pistol-custom-prefs:focus {
   outline: none;
   border-color: var(--text-dim);
@@ -1367,6 +1437,7 @@ body {
 #prompt-modal {
   z-index: 10000;
 }
+
 .confirm-modal-box {
   max-width: 380px;
   text-align: center;
@@ -1408,6 +1479,7 @@ body {
   outline: none;
   box-sizing: border-box;
 }
+
 .prompt-modal-input:focus {
   border-color: var(--gold);
 }
@@ -1416,6 +1488,24 @@ body {
 .debug-panel-content {
   max-width: 860px;
   width: 95%;
+  max-height: 90vh;
+  /* Allow it to be taller than default */
+  display: flex;
+  flex-direction: column;
+  overflow: hidden !important;
+  /* Prevent the entire modal from scrolling to keep header/footer visible */
+}
+
+.debug-panel-body {
+  flex: 1;
+  min-height: 0;
+  /* Crucial for flex scrolling */
+  overflow-y: auto;
+  overflow-x: hidden;
+  display: flex;
+  flex-direction: column;
+  padding-right: 8px;
+  /* space for scrollbar */
 }
 
 .debug-panel-header {
@@ -1438,7 +1528,9 @@ body {
 }
 
 .debug-chat-messages {
-  max-height: 34vh;
+  flex: 1;
+  min-height: 200px;
+  max-height: 40vh;
   overflow-y: auto;
   border: 1px solid var(--border);
   border-radius: var(--radius);
@@ -1473,6 +1565,27 @@ body {
   margin-bottom: 4px;
 }
 
+.debug-thinking {
+  font-style: italic;
+  color: var(--text-dim);
+  opacity: 0.8;
+  animation: pulse 1.5s infinite ease-in-out;
+}
+
+@keyframes pulse {
+  0% {
+    opacity: 0.4;
+  }
+
+  50% {
+    opacity: 1;
+  }
+
+  100% {
+    opacity: 0.4;
+  }
+}
+
 .debug-chat-input-row {
   display: flex;
   gap: 10px;
@@ -1481,8 +1594,8 @@ body {
 
 #debug-chat-input {
   flex: 1;
-  min-height: 60px;
-  max-height: 140px;
+  min-height: 80px;
+  max-height: 180px;
   resize: vertical;
   padding: 8px 10px;
   border: 1px solid var(--border);
@@ -1530,13 +1643,14 @@ body {
 
 .debug-item-json {
   width: 100%;
-  min-height: 72px;
+  min-height: 120px;
   resize: vertical;
   border: 1px solid var(--border);
   border-radius: var(--radius);
   background: var(--input-bg);
   color: var(--text);
   font-size: 0.82rem;
+  line-height: 1.4;
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
   padding: 8px;
 }
@@ -1544,6 +1658,8 @@ body {
 .debug-panel-actions {
   display: flex;
   gap: 10px;
+  margin-top: auto;
+  padding-top: 12px;
 }
 
 .debug-apply-result {
@@ -1744,9 +1860,11 @@ body {
   padding: 2px 4px;
   transition: color 0.15s;
 }
+
 .save-edit:hover {
   color: var(--gold);
 }
+
 .save-delete {
   cursor: pointer;
   color: var(--text-dim);
@@ -1755,6 +1873,7 @@ body {
   border-radius: 3px;
   transition: color 0.15s;
 }
+
 .save-delete:hover {
   color: var(--accent);
 }
@@ -1786,10 +1905,12 @@ body {
   cursor: pointer;
   transition: background 0.15s, color 0.15s;
 }
+
 .save-load-btn:hover {
   background: var(--gold);
   color: var(--bg-dark);
 }
+
 .save-load-btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
@@ -2008,9 +2129,18 @@ body {
   color: var(--text-dim);
 }
 
-.stm-metric b { color: var(--gold); font-weight: 700; }
-.stm-metric-sep { color: var(--border); }
-.stm-phase-dungeon { color: var(--accent); }
+.stm-metric b {
+  color: var(--gold);
+  font-weight: 700;
+}
+
+.stm-metric-sep {
+  color: var(--border);
+}
+
+.stm-phase-dungeon {
+  color: var(--accent);
+}
 
 .summary-modal-close-btn {
   position: absolute;
@@ -2024,7 +2154,11 @@ body {
   padding: 4px 8px;
   border-radius: 4px;
 }
-.summary-modal-close-btn:hover { color: var(--text); background: var(--border); }
+
+.summary-modal-close-btn:hover {
+  color: var(--text);
+  background: var(--border);
+}
 
 .summary-modal-body {
   flex: 1;
@@ -2032,8 +2166,14 @@ body {
   padding: 20px 24px 24px;
 }
 
-.summary-modal-body::-webkit-scrollbar { width: 6px; }
-.summary-modal-body::-webkit-scrollbar-track { background: transparent; }
+.summary-modal-body::-webkit-scrollbar {
+  width: 6px;
+}
+
+.summary-modal-body::-webkit-scrollbar-track {
+  background: transparent;
+}
+
 .summary-modal-body::-webkit-scrollbar-thumb {
   background: var(--border);
   border-radius: 3px;
@@ -2059,7 +2199,10 @@ body {
   position: relative;
   margin-bottom: 20px;
 }
-.stm-node:last-child { margin-bottom: 0; }
+
+.stm-node:last-child {
+  margin-bottom: 0;
+}
 
 .stm-dot {
   position: absolute;
@@ -2123,6 +2266,7 @@ body {
   cursor: pointer;
   transition: background 0.2s, border-color 0.2s;
 }
+
 .summary-open-modal-btn:hover {
   background: var(--border);
   border-color: var(--gold);
@@ -2181,22 +2325,27 @@ body {
   font-size: 0.85rem;
   transition: all 0.2s;
 }
+
 .cheat-toggle:hover {
   background: var(--bg-user);
   border-color: var(--text-dim);
 }
+
 .cheat-toggle:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
+
 .cheat-toggle.active {
   background: #2a4a2a;
   border-color: #4a8;
   color: #6fc;
 }
+
 .cheat-toggle.active:hover {
   background: #335a33;
 }
+
 .cheat-toggle.disabled {
   opacity: 0.35;
   pointer-events: none;
@@ -2214,6 +2363,7 @@ body {
   color: #6fc;
   background: rgba(68, 170, 136, 0.15);
 }
+
 #cheat-badge.visible {
   display: inline-flex;
 }
@@ -2230,6 +2380,7 @@ body {
   color: #f9a8d4;
   background: rgba(249, 168, 212, 0.15);
 }
+
 #pistol-badge.visible {
   display: inline-flex;
 }
@@ -2263,8 +2414,13 @@ body {
     font-size: 1rem;
   }
 
-  .header-title-full { display: none; }
-  .header-title-short { display: inline; }
+  .header-title-full {
+    display: none;
+  }
+
+  .header-title-short {
+    display: inline;
+  }
 
   .branch-indicator {
     margin-left: auto;
@@ -2339,17 +2495,29 @@ body {
     padding: 4px 10px;
     font-size: 0.85rem;
   }
+
   .sw-delete {
     opacity: 0.5;
   }
+
   .sw-prune {
     opacity: 0.5;
   }
 
   /* Mobile: msg-index always visible; report button shown on tap */
-  .msg-index { opacity: 0.25; }
-  .msg-report-btn { opacity: 0; font-size: 0.85rem; padding: 6px 8px; }
-  .message.touched .msg-report-btn { opacity: 0.4; }
+  .msg-index {
+    opacity: 0.25;
+  }
+
+  .msg-report-btn {
+    opacity: 0;
+    font-size: 0.85rem;
+    padding: 6px 8px;
+  }
+
+  .message.touched .msg-report-btn {
+    opacity: 0.4;
+  }
 
   /* GM options: subtle rest-state affordance for touch */
   .gm-option-li,
@@ -2390,8 +2558,13 @@ body {
     padding: 14px 16px 16px;
   }
 
-  .header-sub { display: none; }
-  #world-day-display { font-size: 0.75rem; }
+  .header-sub {
+    display: none;
+  }
+
+  #world-day-display {
+    font-size: 0.75rem;
+  }
 
   /* Addon panel: near full-width on mobile */
   .addon-panel {
@@ -2415,9 +2588,14 @@ body {
   }
 
   /* Branch tree: always show action buttons on mobile (no hover) */
-  .bt-actions { opacity: 1 !important; }
+  .bt-actions {
+    opacity: 1 !important;
+  }
+
   /* Drawer branch actions: always visible on touch devices */
-  .drawer-item .drawer-item-action { opacity: 0.6; }
+  .drawer-item .drawer-item-action {
+    opacity: 0.6;
+  }
 }
 
 /* ---------- Branch Tree Modal ---------- */
@@ -2430,6 +2608,7 @@ body {
   flex-direction: column;
   overflow: hidden;
 }
+
 .branch-tree-modal-header {
   display: flex;
   align-items: center;
@@ -2437,16 +2616,19 @@ body {
   border-bottom: 1px solid var(--border);
   position: relative;
 }
+
 .branch-tree-modal-header h2 {
   font-size: 1.1rem;
   margin: 0;
 }
+
 .bt-toolbar {
   display: flex;
   align-items: center;
   gap: 6px;
   margin-left: 12px;
 }
+
 .bt-toolbar-btn {
   background: none;
   border: 1px solid var(--border);
@@ -2457,30 +2639,60 @@ body {
   font-size: 0.8rem;
   transition: all 0.15s;
 }
-.bt-toolbar-btn:hover { color: var(--text); border-color: var(--text-dim); }
-.bt-toolbar-btn.bt-danger { color: var(--accent); border-color: var(--accent); }
-.bt-toolbar-btn.bt-danger:hover { background: rgba(217, 48, 37, 0.1); }
-.bt-toolbar-btn.bt-merge { color: var(--gold); border-color: var(--gold); }
-.bt-toolbar-btn.bt-merge:hover { background: rgba(184, 134, 11, 0.1); }
-.bt-toolbar-btn.bt-continue { color: var(--gold); border-color: var(--gold); }
-.bt-toolbar-btn.bt-continue:hover { background: rgba(184, 134, 11, 0.15); }
+
+.bt-toolbar-btn:hover {
+  color: var(--text);
+  border-color: var(--text-dim);
+}
+
+.bt-toolbar-btn.bt-danger {
+  color: var(--accent);
+  border-color: var(--accent);
+}
+
+.bt-toolbar-btn.bt-danger:hover {
+  background: rgba(217, 48, 37, 0.1);
+}
+
+.bt-toolbar-btn.bt-merge {
+  color: var(--gold);
+  border-color: var(--gold);
+}
+
+.bt-toolbar-btn.bt-merge:hover {
+  background: rgba(184, 134, 11, 0.1);
+}
+
+.bt-toolbar-btn.bt-continue {
+  color: var(--gold);
+  border-color: var(--gold);
+}
+
+.bt-toolbar-btn.bt-continue:hover {
+  background: rgba(184, 134, 11, 0.15);
+}
+
 .branch-tree-container {
   flex: 1;
   overflow: auto;
   padding: 16px 20px 24px;
 }
+
 .bt-node {
   position: relative;
   padding-left: 14px;
 }
+
 .bt-node.bt-root {
   padding-left: 0;
 }
+
 .bt-children {
   margin-left: 4px;
   border-left: 1px solid var(--border);
   padding-left: 0;
 }
+
 .bt-item {
   display: flex;
   align-items: center;
@@ -2491,6 +2703,7 @@ body {
   position: relative;
   margin: 0;
 }
+
 .bt-item::before {
   content: "";
   position: absolute;
@@ -2500,28 +2713,35 @@ body {
   height: 1px;
   background: var(--border);
 }
-.bt-root > .bt-item::before {
+
+.bt-root>.bt-item::before {
   display: none;
 }
+
 .bt-chain {
   border-left: 1px dashed var(--border);
   margin-left: 3px;
   padding-left: 11px;
 }
-.bt-chain > .bt-item {
+
+.bt-chain>.bt-item {
   position: relative;
 }
-.bt-chain > .bt-item::before {
+
+.bt-chain>.bt-item::before {
   left: -11px;
   width: 8px;
 }
+
 .bt-item:hover {
   background: rgba(255, 255, 255, 0.05);
 }
+
 .bt-item.bt-active {
   background: rgba(184, 134, 11, 0.15);
   border: 1px solid var(--gold);
 }
+
 .bt-dot {
   width: 8px;
   height: 8px;
@@ -2529,10 +2749,12 @@ body {
   background: var(--text-dim);
   flex-shrink: 0;
 }
+
 .bt-active .bt-dot {
   background: var(--gold);
   box-shadow: 0 0 6px rgba(184, 134, 11, 0.5);
 }
+
 .bt-name {
   font-size: 0.88rem;
   color: var(--text);
@@ -2541,12 +2763,14 @@ body {
   text-overflow: ellipsis;
   max-width: 280px;
 }
+
 .bt-id {
   font-size: 0.7rem;
   color: var(--text-dim);
   opacity: 0.6;
   flex-shrink: 0;
 }
+
 .bt-auto-badge {
   padding: 1px 5px;
   border-radius: 3px;
@@ -2556,6 +2780,7 @@ body {
   color: #ff6b6b;
   flex-shrink: 0;
 }
+
 .bt-toggle {
   cursor: pointer;
   font-size: 0.55rem;
@@ -2564,12 +2789,15 @@ body {
   flex-shrink: 0;
   padding: 2px;
 }
+
 .bt-toggle.expanded {
   transform: rotate(90deg);
 }
+
 .bt-children.collapsed {
   display: none;
 }
+
 .bt-checkbox {
   width: 14px;
   height: 14px;
@@ -2577,7 +2805,12 @@ body {
   flex-shrink: 0;
   cursor: pointer;
 }
-.bt-checkbox.hidden, .bt-actions.hidden { display: none; }
+
+.bt-checkbox.hidden,
+.bt-actions.hidden {
+  display: none;
+}
+
 .bt-actions {
   display: flex;
   gap: 2px;
@@ -2586,7 +2819,11 @@ body {
   opacity: 0;
   transition: opacity 0.15s;
 }
-.bt-item:hover .bt-actions { opacity: 1; }
+
+.bt-item:hover .bt-actions {
+  opacity: 1;
+}
+
 .bt-action-btn {
   cursor: pointer;
   font-size: 0.75rem;
@@ -2594,15 +2831,48 @@ body {
   padding: 4px 5px;
   border-radius: 3px;
 }
-.bt-action-btn:hover { color: var(--text); background: rgba(255,255,255,0.08); }
-.bt-action-del:hover { color: var(--accent); }
-.bt-action-heart { font-size: 0.85rem; }
-.bt-action-heart:hover { color: #ff6b9d; background: rgba(255,107,157,0.1); }
-.bt-action-promote { font-size: 0.75rem; }
-.bt-action-promote:hover { color: #4fc3f7; background: rgba(79,195,247,0.1); }
-.bt-action-deep { color: #6bb5ff; }
-.bt-action-deep:hover { color: #9dd0ff; background: rgba(107, 181, 255, 0.1); }
-.bt-protected-badge { font-size: 0.65rem; color: #ff6b9d; margin-left: 2px; }
+
+.bt-action-btn:hover {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.bt-action-del:hover {
+  color: var(--accent);
+}
+
+.bt-action-heart {
+  font-size: 0.85rem;
+}
+
+.bt-action-heart:hover {
+  color: #ff6b9d;
+  background: rgba(255, 107, 157, 0.1);
+}
+
+.bt-action-promote {
+  font-size: 0.75rem;
+}
+
+.bt-action-promote:hover {
+  color: #4fc3f7;
+  background: rgba(79, 195, 247, 0.1);
+}
+
+.bt-action-deep {
+  color: #6bb5ff;
+}
+
+.bt-action-deep:hover {
+  color: #9dd0ff;
+  background: rgba(107, 181, 255, 0.1);
+}
+
+.bt-protected-badge {
+  font-size: 0.65rem;
+  color: #ff6b9d;
+  margin-left: 2px;
+}
 
 /* ---------- Message index label (#5) ---------- */
 .msg-index {
@@ -2615,7 +2885,11 @@ body {
   pointer-events: none;
   font-family: monospace;
 }
-.message.gm .msg-index { right: auto; left: 0; }
+
+.message.gm .msg-index {
+  right: auto;
+  left: 0;
+}
 
 /* ---------- Bug report button (#6) ---------- */
 .msg-report-btn {
@@ -2630,17 +2904,34 @@ body {
   opacity: 0;
   transition: opacity 0.15s, color 0.15s;
 }
-.message:hover .msg-report-btn { opacity: 0.5; }
-.msg-report-btn:hover { opacity: 1 !important; color: var(--accent); }
-.message.gm .msg-report-btn { left: 52px; }
-.message.user .msg-report-btn { right: 56px; }
+
+.message:hover .msg-report-btn {
+  opacity: 0.5;
+}
+
+.msg-report-btn:hover {
+  opacity: 1 !important;
+  color: var(--accent);
+}
+
+.message.gm .msg-report-btn {
+  left: 52px;
+}
+
+.message.user .msg-report-btn {
+  right: 56px;
+}
 
 .report-modal-overlay {
-  position: fixed; inset: 0;
-  background: rgba(0,0,0,0.6);
-  display: flex; align-items: center; justify-content: center;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
   z-index: 9999;
 }
+
 .report-modal {
   background: var(--bg-sidebar);
   border: 1px solid var(--border);
@@ -2650,16 +2941,18 @@ body {
   max-height: 80vh;
   overflow-y: auto;
 }
+
 .report-info {
   font-size: 0.75rem;
   color: var(--text-dim);
   margin-bottom: 8px;
   font-family: monospace;
 }
+
 .report-preview {
   font-size: 0.8rem;
   color: var(--text-dim);
-  background: rgba(0,0,0,0.2);
+  background: rgba(0, 0, 0, 0.2);
   padding: 8px;
   border-radius: 4px;
   margin-bottom: 12px;
@@ -2667,6 +2960,7 @@ body {
   overflow: hidden;
   white-space: pre-wrap;
 }
+
 .report-textarea {
   width: 100%;
   min-height: 80px;
@@ -2681,7 +2975,11 @@ body {
   outline: none;
   margin-bottom: 12px;
 }
-.report-textarea:focus { border-color: var(--accent); }
+
+.report-textarea:focus {
+  border-color: var(--accent);
+}
+
 .report-actions {
   display: flex;
   gap: 8px;
@@ -2700,8 +2998,16 @@ body {
   opacity: 0;
   transition: opacity 0.2s, color 0.2s;
 }
-.sibling-switcher:hover .sw-prune { opacity: 0.6; }
-.sw-prune:hover { opacity: 1 !important; color: var(--gold); }
+
+.sibling-switcher:hover .sw-prune {
+  opacity: 0.6;
+}
+
+.sw-prune:hover {
+  opacity: 1 !important;
+  color: var(--gold);
+}
+
 .sw-heart {
   background: none;
   border: none;
@@ -2710,7 +3016,10 @@ body {
   font-size: 0.8rem;
   padding: 2px 4px;
 }
-.sw-heart:hover { color: #ff6b9d; }
+
+.sw-heart:hover {
+  color: #ff6b9d;
+}
 
 /* ---------- Toast message ---------- */
 .toast-msg {
@@ -2729,6 +3038,7 @@ body {
   z-index: 10000;
   pointer-events: none;
 }
+
 .toast-msg.show {
   opacity: 1;
   transform: translateX(-50%) translateY(0);
@@ -2743,6 +3053,7 @@ body {
   margin: 2px -4px;
   transition: background 0.15s, color 0.15s;
 }
+
 .gm-option-li:hover,
 .gm-option-p:hover {
   background: rgba(212, 168, 83, 0.12);
@@ -3013,7 +3324,8 @@ body {
   }
 
   .dungeon-node-hint {
-    display: none;  /* Hide hints on mobile */
+    display: none;
+    /* Hide hints on mobile */
   }
 
   .dungeon-area {

--- a/templates/index.html
+++ b/templates/index.html
@@ -229,6 +229,13 @@
               </div>
             </div>
           </div>
+          <div class="addon-section">
+            <div class="addon-section-title">Debug</div>
+            <div class="addon-toggle-field">
+              <span>修正面板</span>
+              <button id="addon-debug-btn" class="cheat-toggle">開啟</button>
+            </div>
+          </div>
         </div>
       </div>
     </main>
@@ -324,6 +331,38 @@
         <button id="branch-tree-modal-close" class="summary-modal-close-btn">&times;</button>
       </div>
       <div id="branch-tree-container" class="branch-tree-container"></div>
+    </div>
+  </div>
+
+  <!-- Debug Panel Modal -->
+  <div id="debug-panel-modal" class="modal-overlay hidden">
+    <div class="modal-content debug-panel-content">
+      <div class="debug-panel-header">
+        <h2>Debug Panel</h2>
+        <button id="debug-panel-close" class="summary-modal-close-btn">&times;</button>
+      </div>
+      <div class="debug-panel-meta">
+        <span id="debug-target-branch">branch: -</span>
+        <span id="debug-unit-id">unit: -</span>
+      </div>
+      <div id="debug-chat-messages" class="debug-chat-messages"></div>
+      <div class="debug-chat-input-row">
+        <textarea id="debug-chat-input" rows="2" placeholder="輸入要查核或修正的問題..."></textarea>
+        <button id="debug-chat-send" class="modal-create-btn">送出</button>
+      </div>
+      <div class="debug-block">
+        <div class="debug-block-title">修正提案（actions）</div>
+        <div id="debug-proposals" class="debug-items"></div>
+      </div>
+      <div class="debug-block">
+        <div class="debug-block-title">劇情指令（directives）</div>
+        <div id="debug-directives" class="debug-items"></div>
+      </div>
+      <div class="debug-panel-actions">
+        <button id="debug-apply-btn" class="modal-create-btn">套用勾選項目</button>
+        <button id="debug-undo-btn" class="modal-cancel-btn">Undo</button>
+      </div>
+      <div id="debug-apply-result" class="debug-apply-result"></div>
     </div>
   </div>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -366,225 +366,220 @@
           <span id="debug-unit-id">unit: -</span>
         </div>
         <div id="debug-chat-messages" class="debug-chat-messages"></div>
-        <div class="debug-chat-input-row">
-          <textarea id="debug-chat-input" rows="2" placeholder="輸入要查核或修正的問題..."></textarea>
-          <button id="debug-chat-send" class="modal-create-btn">送出</button>
+        <div class="debug-panel-actions">
+          <input type="text" id="debug-chat-input" placeholder="告訴 GM 你想修改什麼 (例如: 給我 100 塊)..." />
+          <button id="debug-chat-send" class="primary">送出</button>
         </div>
-
-        <div id="debug-pending-options-container" class="debug-pending-options-container hidden"></div>
-
-      </div>
-      <div class="debug-panel-actions">
-        <button id="debug-apply-btn" class="modal-create-btn">套用修正</button>
-        <button id="debug-undo-btn" class="modal-cancel-btn">Undo</button>
-        <button id="debug-clear-btn" class="modal-danger-btn" style="margin-left: auto;">清空對話紀錄</button>
-      </div>
-      <div id="debug-apply-result" class="debug-apply-result"></div>
-    </div>
-  </div>
-
-  <!-- Pistol Prefs Modal -->
-  <div id="pistol-prefs-modal" class="modal-overlay hidden">
-    <div class="modal-content pistol-prefs-modal-content">
-      <div class="pistol-prefs-header">
-        <h2>偏好設定</h2>
-        <button id="pistol-prefs-close" class="summary-modal-close-btn">&times;</button>
-      </div>
-      <div class="pistol-prefs-body">
-        <div class="pistol-chips-group">
-          <div class="pistol-chips-label">風格</div>
-          <div class="pistol-chips" data-group="style">
-            <button class="pistol-chip" data-value="浪漫">浪漫<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="激烈">激烈<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="溫柔">溫柔<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="粗暴">粗暴<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="慢節奏">慢節奏<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="挑逗">挑逗<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="禁忌">禁忌<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="野性">野性<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="純愛">純愛<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="背德">背德<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="SM">SM<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="調教">調教<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="NTR">NTR<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="偷情">偷情<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="初體驗">初體驗<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="醉酒迷濛">醉酒迷濛<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="半夢半醒">半夢半醒<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="強制">強制<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="催眠">催眠<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="痴漢">痴漢<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="癡女">癡女<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip-add" data-group="style" title="新增">+</button>
-          </div>
+        <div class="debug-panel-tools">
+          <button id="debug-undo-btn" class="cheat-toggle danger">復原 (Undo)</button>
+          <button id="debug-clear-btn" class="cheat-toggle">清空紀錄</button>
         </div>
-        <div class="pistol-chips-group">
-          <div class="pistol-chips-label">體位</div>
-          <div class="pistol-chips" data-group="positions">
-            <button class="pistol-chip" data-value="正常位">正常位<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="後入">後入<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="騎乘">騎乘<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="側入">側入<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="站立">站立<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="69式">69式<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="背後抱">背後抱<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="壁咚">壁咚<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="跪趴">跪趴<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="坐姿">坐姿<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="懸空抱">懸空抱<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="對面坐">對面坐<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="老漢推車">老漢推車<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="抬腿">抬腿<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="倒騎">倒騎<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="趴在桌上">趴在桌上<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="靠牆">靠牆<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip-add" data-group="positions" title="新增">+</button>
-          </div>
-        </div>
-        <div class="pistol-chips-group">
-          <div class="pistol-chips-label">前戲/技巧</div>
-          <div class="pistol-chips" data-group="foreplay">
-            <button class="pistol-chip" data-value="前戲">前戲<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="愛撫">愛撫<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="接吻">接吻<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="舌吻">舌吻<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="耳語">耳語<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="舔耳">舔耳<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="種草莓">種草莓<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="指交">指交<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="口交">口交<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="深喉">深喉<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="舔舐">舔舐<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="乳交">乳交<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="足交">足交<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="按摩">按摩<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="乳首愛撫">乳首愛撫<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="肛交">肛交<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="打屁股">打屁股<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="咬痕">咬痕<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="窒息play">窒息play<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="顏面騎乘">顏面騎乘<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="乳頭夾">乳頭夾<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip-add" data-group="foreplay" title="新增">+</button>
-          </div>
-        </div>
-        <div class="pistol-chips-group">
-          <div class="pistol-chips-label">高潮/結束</div>
-          <div class="pistol-chips" data-group="climax">
-            <button class="pistol-chip" data-value="內射">內射<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="顏射">顏射<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="口爆">口爆<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="吞精">吞精<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="潮吹">潮吹<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="同時高潮">同時高潮<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="多次高潮">多次高潮<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="高潮控制">高潮控制<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="射在身上">射在身上<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="連續絕頂">連續絕頂<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="失禁">失禁<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="高潮痙攣">高潮痙攣<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="強制高潮">強制高潮<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip-add" data-group="climax" title="新增">+</button>
-          </div>
-        </div>
-        <div class="pistol-chips-group">
-          <div class="pistol-chips-label">道具/情境</div>
-          <div class="pistol-chips" data-group="props">
-            <button class="pistol-chip" data-value="跳蛋">跳蛋<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="按摩棒">按摩棒<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="眼罩">眼罩<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="繩縛">繩縛<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="項圈">項圈<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="皮鞭">皮鞭<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="蠟燭">蠟燭<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="冰塊">冰塊<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="制服">制服<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="絲襪">絲襪<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="角色扮演">角色扮演<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="手銬">手銬<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="口球">口球<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="肛塞">肛塞<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="潤滑液">潤滑液<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="鏡子前">鏡子前<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="攝影">攝影<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="電話中">電話中<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="食物play">食物play<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip-add" data-group="props" title="新增">+</button>
-          </div>
-        </div>
-        <div class="pistol-chips-group">
-          <div class="pistol-chips-label">場景</div>
-          <div class="pistol-chips" data-group="scene">
-            <button class="pistol-chip" data-value="浴室">浴室<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="溫泉">溫泉<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="野外">野外<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="車內">車內<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="公共場所">公共場所<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="偷窺">偷窺<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="露出">露出<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="多人">多人<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="辦公室">辦公室<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="教室">教室<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="更衣室">更衣室<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="電梯">電梯<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="泳池">泳池<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="旅館">旅館<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="帳篷">帳篷<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="廁所">廁所<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip-add" data-group="scene" title="新增">+</button>
-          </div>
-        </div>
-        <div class="pistol-chips-group">
-          <div class="pistol-chips-label">描寫重點</div>
-          <div class="pistol-chips" data-group="focus">
-            <button class="pistol-chip" data-value="情感互動">情感互動<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="肉體描寫">肉體描寫<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="對話呻吟">對話呻吟<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="氛圍營造">氛圍營造<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="表情特寫">表情特寫<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="體液描寫">體液描寫<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="事後餘韻">事後餘韻<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="內心獨白">內心獨白<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="羞恥感">羞恥感<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="征服感">征服感<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="背德快感">背德快感<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="身體顫抖">身體顫抖<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="理性崩壞">理性崩壞<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip-add" data-group="focus" title="新增">+</button>
-          </div>
-        </div>
-        <div class="pistol-chips-group">
-          <div class="pistol-chips-label">角色動態</div>
-          <div class="pistol-chips" data-group="dynamic">
-            <button class="pistol-chip" data-value="玩家主導">玩家主導<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="對方主導">對方主導<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="雙方主動">雙方主動<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="欲拒還迎">欲拒還迎<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="誘惑">誘惑<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="服從">服從<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="強勢壓制">強勢壓制<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="嬌羞">嬌羞<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="央求">央求<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="命令">命令<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="撒嬌">撒嬌<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="挑釁">挑釁<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="哭泣求饒">哭泣求饒<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip" data-value="口嫌體正直">口嫌體正直<span class="chip-delete">&times;</span></button>
-            <button class="pistol-chip-add" data-group="dynamic" title="新增">+</button>
-          </div>
-        </div>
-        <div class="pistol-chips-group">
-          <div class="pistol-chips-label">自訂補充</div>
-          <textarea id="pistol-custom-prefs" rows="2" placeholder="額外描述（可選）…"></textarea>
-        </div>
-      </div>
-      <div class="modal-actions">
-        <button id="pistol-prefs-save" class="modal-create-btn" onclick="savePistolPrefs()">儲存</button>
+        <div id="debug-apply-result" class="debug-result-text"></div>
       </div>
     </div>
-  </div>
 
-  <script src="/static/app.js?v={{ v }}"></script>
+    <!-- Pistol Prefs Modal -->
+    <div id="pistol-prefs-modal" class="modal-overlay hidden">
+      <div class="modal-content pistol-prefs-modal-content">
+        <div class="pistol-prefs-header">
+          <h2>偏好設定</h2>
+          <button id="pistol-prefs-close" class="summary-modal-close-btn">&times;</button>
+        </div>
+        <div class="pistol-prefs-body">
+          <div class="pistol-chips-group">
+            <div class="pistol-chips-label">風格</div>
+            <div class="pistol-chips" data-group="style">
+              <button class="pistol-chip" data-value="浪漫">浪漫<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="激烈">激烈<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="溫柔">溫柔<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="粗暴">粗暴<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="慢節奏">慢節奏<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="挑逗">挑逗<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="禁忌">禁忌<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="野性">野性<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="純愛">純愛<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="背德">背德<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="SM">SM<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="調教">調教<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="NTR">NTR<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="偷情">偷情<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="初體驗">初體驗<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="醉酒迷濛">醉酒迷濛<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="半夢半醒">半夢半醒<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="強制">強制<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="催眠">催眠<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="痴漢">痴漢<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="癡女">癡女<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip-add" data-group="style" title="新增">+</button>
+            </div>
+          </div>
+          <div class="pistol-chips-group">
+            <div class="pistol-chips-label">體位</div>
+            <div class="pistol-chips" data-group="positions">
+              <button class="pistol-chip" data-value="正常位">正常位<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="後入">後入<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="騎乘">騎乘<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="側入">側入<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="站立">站立<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="69式">69式<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="背後抱">背後抱<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="壁咚">壁咚<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="跪趴">跪趴<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="坐姿">坐姿<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="懸空抱">懸空抱<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="對面坐">對面坐<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="老漢推車">老漢推車<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="抬腿">抬腿<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="倒騎">倒騎<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="趴在桌上">趴在桌上<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="靠牆">靠牆<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip-add" data-group="positions" title="新增">+</button>
+            </div>
+          </div>
+          <div class="pistol-chips-group">
+            <div class="pistol-chips-label">前戲/技巧</div>
+            <div class="pistol-chips" data-group="foreplay">
+              <button class="pistol-chip" data-value="前戲">前戲<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="愛撫">愛撫<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="接吻">接吻<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="舌吻">舌吻<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="耳語">耳語<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="舔耳">舔耳<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="種草莓">種草莓<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="指交">指交<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="口交">口交<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="深喉">深喉<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="舔舐">舔舐<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="乳交">乳交<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="足交">足交<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="按摩">按摩<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="乳首愛撫">乳首愛撫<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="肛交">肛交<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="打屁股">打屁股<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="咬痕">咬痕<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="窒息play">窒息play<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="顏面騎乘">顏面騎乘<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="乳頭夾">乳頭夾<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip-add" data-group="foreplay" title="新增">+</button>
+            </div>
+          </div>
+          <div class="pistol-chips-group">
+            <div class="pistol-chips-label">高潮/結束</div>
+            <div class="pistol-chips" data-group="climax">
+              <button class="pistol-chip" data-value="內射">內射<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="顏射">顏射<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="口爆">口爆<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="吞精">吞精<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="潮吹">潮吹<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="同時高潮">同時高潮<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="多次高潮">多次高潮<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="高潮控制">高潮控制<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="射在身上">射在身上<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="連續絕頂">連續絕頂<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="失禁">失禁<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="高潮痙攣">高潮痙攣<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="強制高潮">強制高潮<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip-add" data-group="climax" title="新增">+</button>
+            </div>
+          </div>
+          <div class="pistol-chips-group">
+            <div class="pistol-chips-label">道具/情境</div>
+            <div class="pistol-chips" data-group="props">
+              <button class="pistol-chip" data-value="跳蛋">跳蛋<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="按摩棒">按摩棒<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="眼罩">眼罩<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="繩縛">繩縛<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="項圈">項圈<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="皮鞭">皮鞭<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="蠟燭">蠟燭<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="冰塊">冰塊<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="制服">制服<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="絲襪">絲襪<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="角色扮演">角色扮演<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="手銬">手銬<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="口球">口球<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="肛塞">肛塞<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="潤滑液">潤滑液<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="鏡子前">鏡子前<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="攝影">攝影<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="電話中">電話中<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="食物play">食物play<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip-add" data-group="props" title="新增">+</button>
+            </div>
+          </div>
+          <div class="pistol-chips-group">
+            <div class="pistol-chips-label">場景</div>
+            <div class="pistol-chips" data-group="scene">
+              <button class="pistol-chip" data-value="浴室">浴室<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="溫泉">溫泉<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="野外">野外<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="車內">車內<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="公共場所">公共場所<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="偷窺">偷窺<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="露出">露出<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="多人">多人<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="辦公室">辦公室<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="教室">教室<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="更衣室">更衣室<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="電梯">電梯<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="泳池">泳池<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="旅館">旅館<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="帳篷">帳篷<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="廁所">廁所<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip-add" data-group="scene" title="新增">+</button>
+            </div>
+          </div>
+          <div class="pistol-chips-group">
+            <div class="pistol-chips-label">描寫重點</div>
+            <div class="pistol-chips" data-group="focus">
+              <button class="pistol-chip" data-value="情感互動">情感互動<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="肉體描寫">肉體描寫<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="對話呻吟">對話呻吟<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="氛圍營造">氛圍營造<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="表情特寫">表情特寫<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="體液描寫">體液描寫<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="事後餘韻">事後餘韻<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="內心獨白">內心獨白<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="羞恥感">羞恥感<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="征服感">征服感<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="背德快感">背德快感<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="身體顫抖">身體顫抖<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="理性崩壞">理性崩壞<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip-add" data-group="focus" title="新增">+</button>
+            </div>
+          </div>
+          <div class="pistol-chips-group">
+            <div class="pistol-chips-label">角色動態</div>
+            <div class="pistol-chips" data-group="dynamic">
+              <button class="pistol-chip" data-value="玩家主導">玩家主導<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="對方主導">對方主導<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="雙方主動">雙方主動<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="欲拒還迎">欲拒還迎<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="誘惑">誘惑<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="服從">服從<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="強勢壓制">強勢壓制<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="嬌羞">嬌羞<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="央求">央求<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="命令">命令<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="撒嬌">撒嬌<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="挑釁">挑釁<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="哭泣求饒">哭泣求饒<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip" data-value="口嫌體正直">口嫌體正直<span class="chip-delete">&times;</span></button>
+              <button class="pistol-chip-add" data-group="dynamic" title="新增">+</button>
+            </div>
+          </div>
+          <div class="pistol-chips-group">
+            <div class="pistol-chips-label">自訂補充</div>
+            <textarea id="pistol-custom-prefs" rows="2" placeholder="額外描述（可選）…"></textarea>
+          </div>
+        </div>
+        <div class="modal-actions">
+          <button id="pistol-prefs-save" class="modal-create-btn" onclick="savePistolPrefs()">儲存</button>
+        </div>
+      </div>
+    </div>
+
+    <script src="/static/app.js?v={{ v }}"></script>
 </body>
 
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -365,6 +365,16 @@
           <span id="debug-target-branch">branch: -</span>
           <span id="debug-unit-id">unit: -</span>
         </div>
+        <div id="debug-pending-directive-container" class="debug-pending-directive-container hidden">
+          <div id="debug-pending-directive-header" class="debug-pending-directive-header">
+            <span class="directive-label">📝 1 則待執行指令</span>
+            <div class="directive-header-actions">
+              <span id="debug-pending-directive-cancel" class="directive-cancel-btn" title="撤銷此指令">&times;</span>
+              <span class="directive-toggle-icon">▼</span>
+            </div>
+          </div>
+          <div id="debug-pending-directive-content" class="debug-pending-directive-content"></div>
+        </div>
         <div id="debug-chat-messages" class="debug-chat-messages"></div>
         <div class="debug-chat-input-row">
           <textarea id="debug-chat-input" rows="2" placeholder="告訴 GM 你想修改什麼 (例如: 給我 100 塊)..."></textarea>

--- a/templates/index.html
+++ b/templates/index.html
@@ -366,16 +366,16 @@
           <span id="debug-unit-id">unit: -</span>
         </div>
         <div id="debug-chat-messages" class="debug-chat-messages"></div>
-        <div class="debug-panel-actions">
-          <input type="text" id="debug-chat-input" placeholder="告訴 GM 你想修改什麼 (例如: 給我 100 塊)..." />
-          <button id="debug-chat-send" class="primary">送出</button>
+        <div class="debug-chat-input-row">
+          <textarea id="debug-chat-input" rows="2" placeholder="告訴 GM 你想修改什麼 (例如: 給我 100 塊)..."></textarea>
+          <button id="debug-chat-send" class="modal-create-btn">送出</button>
         </div>
-        <div class="debug-panel-tools">
-          <button id="debug-undo-btn" class="cheat-toggle danger">復原 (Undo)</button>
-          <button id="debug-clear-btn" class="cheat-toggle">清空紀錄</button>
-        </div>
-        <div id="debug-apply-result" class="debug-result-text"></div>
       </div>
+      <div class="debug-panel-actions">
+        <button id="debug-undo-btn" class="modal-cancel-btn">Undo</button>
+        <button id="debug-clear-btn" class="modal-danger-btn" style="margin-left: auto;">清空對話紀錄</button>
+      </div>
+      <div id="debug-apply-result" class="debug-apply-result"></div>
     </div>
 
     <!-- Pistol Prefs Modal -->

--- a/templates/index.html
+++ b/templates/index.html
@@ -371,6 +371,8 @@
           <button id="debug-chat-send" class="modal-create-btn">送出</button>
         </div>
 
+        <div id="debug-pending-options-container" class="debug-pending-options-container hidden"></div>
+
       </div>
       <div class="debug-panel-actions">
         <button id="debug-apply-btn" class="modal-create-btn">套用修正</button>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,11 +1,13 @@
 <!DOCTYPE html>
 <html lang="zh-Hant">
+
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>主神空間 — 無限輪迴 RPG</title>
   <link rel="stylesheet" href="/static/style.css?v={{ v }}">
 </head>
+
 <body>
   <!-- Header -->
   <header id="header">
@@ -90,8 +92,8 @@
     <div class="drawer-section" id="dungeon-section" style="display:none;">
       <div class="drawer-section-title">
         <span>⚔️ 副本進度</span>
-        <button id="dungeon-exit-btn" class="drawer-add-btn dungeon-exit-btn"
-                title="回歸主神空間（需主線 100%）" style="display:none;">
+        <button id="dungeon-exit-btn" class="drawer-add-btn dungeon-exit-btn" title="回歸主神空間（需主線 100%）"
+          style="display:none;">
           ↩
         </button>
       </div>
@@ -225,7 +227,8 @@
               <span>啟用</span>
               <div class="addon-pistol-controls">
                 <button id="addon-pistol-btn" class="cheat-toggle" onclick="togglePistolMode()">OFF</button>
-                <button id="addon-pistol-prefs-btn" class="pistol-prefs-btn hidden" onclick="openPistolPrefsModal()" title="偏好設定">&#x2699;</button>
+                <button id="addon-pistol-prefs-btn" class="pistol-prefs-btn hidden" onclick="openPistolPrefsModal()"
+                  title="偏好設定">&#x2699;</button>
               </div>
             </div>
           </div>
@@ -259,7 +262,8 @@
       </div>
       <div class="modal-field">
         <label for="ns-schema">角色 Schema (JSON)</label>
-        <textarea id="ns-schema" rows="6" placeholder='{"fields": [...], "lists": [...], "direct_overwrite_keys": [...]}'></textarea>
+        <textarea id="ns-schema" rows="6"
+          placeholder='{"fields": [...], "lists": [...], "direct_overwrite_keys": [...]}'></textarea>
       </div>
       <div class="modal-field">
         <label for="ns-state">初始角色狀態 (JSON)</label>
@@ -341,26 +345,22 @@
         <h2>Debug Panel</h2>
         <button id="debug-panel-close" class="summary-modal-close-btn">&times;</button>
       </div>
-      <div class="debug-panel-meta">
-        <span id="debug-target-branch">branch: -</span>
-        <span id="debug-unit-id">unit: -</span>
-      </div>
-      <div id="debug-chat-messages" class="debug-chat-messages"></div>
-      <div class="debug-chat-input-row">
-        <textarea id="debug-chat-input" rows="2" placeholder="輸入要查核或修正的問題..."></textarea>
-        <button id="debug-chat-send" class="modal-create-btn">送出</button>
-      </div>
-      <div class="debug-block">
-        <div class="debug-block-title">修正提案（actions）</div>
-        <div id="debug-proposals" class="debug-items"></div>
-      </div>
-      <div class="debug-block">
-        <div class="debug-block-title">劇情指令（directives）</div>
-        <div id="debug-directives" class="debug-items"></div>
+      <div class="debug-panel-body">
+        <div class="debug-panel-meta">
+          <span id="debug-target-branch">branch: -</span>
+          <span id="debug-unit-id">unit: -</span>
+        </div>
+        <div id="debug-chat-messages" class="debug-chat-messages"></div>
+        <div class="debug-chat-input-row">
+          <textarea id="debug-chat-input" rows="2" placeholder="輸入要查核或修正的問題..."></textarea>
+          <button id="debug-chat-send" class="modal-create-btn">送出</button>
+        </div>
+
       </div>
       <div class="debug-panel-actions">
-        <button id="debug-apply-btn" class="modal-create-btn">套用勾選項目</button>
+        <button id="debug-apply-btn" class="modal-create-btn">套用修正</button>
         <button id="debug-undo-btn" class="modal-cancel-btn">Undo</button>
+        <button id="debug-clear-btn" class="modal-danger-btn" style="margin-left: auto;">清空對話紀錄</button>
       </div>
       <div id="debug-apply-result" class="debug-apply-result"></div>
     </div>
@@ -569,4 +569,5 @@
 
   <script src="/static/app.js?v={{ v }}"></script>
 </body>
+
 </html>

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -356,6 +356,20 @@ class TestBranchesAPI:
         child_plan_path = setup_story / "branches" / child_id / "gm_plan.json"
         assert not child_plan_path.exists()
 
+    def test_create_branch_does_not_copy_debug_directive(self, client, setup_story):
+        main_directive_path = setup_story / "branches" / "main" / "debug_directive.json"
+        main_directive_path.write_text(json.dumps({
+            "instruction": "下回合請補主線提示",
+            "source": "debug_panel",
+        }, ensure_ascii=False), encoding="utf-8")
+
+        resp = client.post("/api/branches", json={"name": "不帶directive", "branch_point_index": 1})
+        assert resp.status_code == 200
+        child_id = resp.get_json()["branch"]["id"]
+
+        child_directive_path = setup_story / "branches" / child_id / "debug_directive.json"
+        assert not child_directive_path.exists()
+
     def test_switch_branch(self, client, setup_story):
         # Create a branch first
         resp = client.post("/api/branches", json={"name": "切換用", "branch_point_index": 1})

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -1370,3 +1370,65 @@ class TestCheatsAPI:
 
         resp2 = client.get("/api/cheats/pistol")
         assert resp2.get_json()["pistol_mode"] is True
+
+
+# ===================================================================
+# Debug Panel
+# ===================================================================
+
+
+class TestDebugAPI:
+    def test_get_debug_session(self, client, setup_story):
+        resp = client.get("/api/debug/session?branch_id=main")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["ok"] is True
+        assert data["target_branch_id"] == "main"
+        assert "debug_unit_id" in data
+        assert isinstance(data["messages"], list)
+
+    def test_debug_chat_stream_contract(self, client, setup_story, monkeypatch):
+        def _fake_stream(*_args, **_kwargs):
+            yield ("text", "先檢查資料。")
+            yield ("done", {
+                "response": (
+                    "先檢查資料。"
+                    "<!--DEBUG_ACTION {\"type\":\"state_patch\",\"update\":{\"reward_points_delta\":10}} DEBUG_ACTION-->"
+                    "<!--DEBUG_DIRECTIVE {\"instruction\":\"下一回合請回收主線提示\"} DEBUG_DIRECTIVE-->"
+                ),
+                "usage": None,
+            })
+
+        monkeypatch.setattr(app_module, "call_claude_gm_stream", _fake_stream)
+        resp = client.post("/api/debug/chat/stream", json={
+            "branch_id": "main",
+            "user_message": "檢查一下獎勵點",
+        })
+        assert resp.status_code == 200
+        body = b"".join(resp.response).decode("utf-8")
+        done_lines = [ln for ln in body.splitlines() if ln.startswith("data: ")]
+        assert done_lines
+        done_payload = json.loads(done_lines[-1][6:])
+        assert done_payload["type"] == "done"
+        assert isinstance(done_payload.get("proposals"), list)
+        assert isinstance(done_payload.get("directives"), list)
+
+    def test_debug_apply_and_undo_contract(self, client, setup_story):
+        apply_resp = client.post("/api/debug/apply", json={
+            "branch_id": "main",
+            "actions": [{"type": "state_patch", "update": {"reward_points_delta": 20}}],
+            "directives": [{"instruction": "下回合推進主線"}],
+        })
+        assert apply_resp.status_code == 200
+        data = apply_resp.get_json()
+        assert data["ok"] is True
+        assert "results" in data
+        assert "directive_result" in data
+        assert "audit_summary" in data
+
+        undo_resp = client.post("/api/debug/undo", json={"branch_id": "main"})
+        assert undo_resp.status_code == 200
+        undo = undo_resp.get_json()
+        assert undo["ok"] is True
+        assert undo["restored"] is True
+        assert "audit_summary" in undo

--- a/tests/test_compaction.py
+++ b/tests/test_compaction.py
@@ -173,6 +173,15 @@ class TestFormatMessages:
         assert "可選行動" not in text
         assert "你站在門口。" in text
 
+    def test_skips_debug_audit_messages(self):
+        msgs = [
+            {"role": "system", "message_type": "debug_audit", "content": "已套用 2/3 項修正"},
+            {"role": "user", "content": "我想繼續主線"},
+        ]
+        text = compaction._format_messages(msgs)
+        assert "已套用 2/3 項修正" not in text
+        assert "我想繼續主線" in text
+
 
 # ===================================================================
 # load_recap / save_recap / get_recap_text

--- a/tests/test_context_injection.py
+++ b/tests/test_context_injection.py
@@ -338,6 +338,48 @@ class TestBuildAugmentedMessage:
         assert block.startswith("[GM 敘事計劃（僅供 GM 內部參考，勿透露給玩家）]")
         assert len(block) <= 120
 
+    @mock.patch("app.search_relevant_lore", return_value="")
+    @mock.patch("app.search_relevant_events", return_value="")
+    @mock.patch("app.get_recent_activities", return_value="[NPC 近期動態]\n- 阿豪：觀察中")
+    @mock.patch("app.is_gm_command", return_value=False)
+    @mock.patch("app.get_fate_mode", return_value=False)
+    def test_debug_directive_injected_between_plan_and_npc_activity(
+        self, _mock_fate, _mock_gm, _mock_act, _mock_evt, _mock_lore, story_id, setup_story
+    ):
+        branch_dir = setup_story / "branches" / "main"
+        (branch_dir / "gm_plan.json").write_text(json.dumps({
+            "arc": "主線推進",
+            "next_beats": ["確認任務", "觸發回收"],
+            "must_payoff": [],
+            "updated_at_index": 3,
+        }, ensure_ascii=False), encoding="utf-8")
+        (branch_dir / "debug_directive.json").write_text(json.dumps({
+            "instruction": "下一回合請檢查主線任務是否完成並補提示。"
+        }, ensure_ascii=False), encoding="utf-8")
+
+        text, _ = app_module._build_augmented_message(
+            story_id, "main", "我繼續前進", {"current_phase": "副本中"}, current_index=8
+        )
+
+        gm_idx = text.find("[GM 敘事計劃（僅供 GM 內部參考，勿透露給玩家）]")
+        dbg_idx = text.find("[Debug 修正指令（僅供 GM 內部參考，勿透露給玩家）]")
+        npc_idx = text.find("[NPC 近期動態]")
+        assert gm_idx != -1
+        assert dbg_idx != -1
+        assert npc_idx != -1
+        assert gm_idx < dbg_idx < npc_idx
+
+    def test_process_gm_response_consumes_debug_directive(self, story_id, setup_story, monkeypatch):
+        branch_dir = setup_story / "branches" / "main"
+        directive_path = branch_dir / "debug_directive.json"
+        directive_path.write_text(json.dumps({
+            "instruction": "下一回合推進主線"
+        }, ensure_ascii=False), encoding="utf-8")
+
+        monkeypatch.setattr(app_module, "_extract_tags_async", lambda *a, **kw: None)
+        app_module._process_gm_response("一般回覆內容", story_id, "main", msg_index=1)
+        assert not directive_path.exists()
+
 
 # ===================================================================
 # _build_story_system_prompt

--- a/tests/test_debug_api.py
+++ b/tests/test_debug_api.py
@@ -1,0 +1,236 @@
+"""Tests for Debug Panel API routes."""
+
+import json
+
+import pytest
+
+import app as app_module
+import event_db
+import lore_db
+import state_db
+
+
+@pytest.fixture(autouse=True)
+def patch_app_paths(tmp_path, monkeypatch):
+    data_dir = tmp_path / "data"
+    stories_dir = data_dir / "stories"
+    stories_dir.mkdir(parents=True)
+    design_dir = tmp_path / "story_design"
+    design_dir.mkdir()
+    monkeypatch.setattr(app_module, "BASE_DIR", str(tmp_path))
+    monkeypatch.setattr(app_module, "DATA_DIR", str(data_dir))
+    monkeypatch.setattr(app_module, "STORIES_DIR", str(stories_dir))
+    monkeypatch.setattr(app_module, "STORY_DESIGN_DIR", str(design_dir))
+    monkeypatch.setattr(app_module, "STORIES_REGISTRY_PATH", str(data_dir / "stories.json"))
+    monkeypatch.setattr(event_db, "STORIES_DIR", str(stories_dir))
+    monkeypatch.setattr(lore_db, "STORIES_DIR", str(stories_dir))
+    monkeypatch.setattr(lore_db, "STORY_DESIGN_DIR", str(design_dir))
+    monkeypatch.setattr(state_db, "STORIES_DIR", str(stories_dir))
+    lore_db._embedding_cache.clear()
+    monkeypatch.setattr(app_module, "_log_llm_usage", lambda *a, **kw: None)
+    return stories_dir
+
+
+@pytest.fixture
+def client():
+    app_module.app.config["TESTING"] = True
+    with app_module.app.test_client() as c:
+        yield c
+
+
+@pytest.fixture
+def story_id():
+    return "test_story"
+
+
+@pytest.fixture
+def setup_story(tmp_path, story_id):
+    stories_dir = tmp_path / "data" / "stories"
+    story_dir = stories_dir / story_id
+    main_branch = story_dir / "branches" / "main"
+    blank_root = story_dir / "branches" / "branch_blank_root"
+    blank_child = story_dir / "branches" / "branch_blank_child"
+    for d in (main_branch, blank_root, blank_child):
+        d.mkdir(parents=True, exist_ok=True)
+
+    design_dir = tmp_path / "story_design" / story_id
+    design_dir.mkdir(parents=True, exist_ok=True)
+
+    (tmp_path / "data" / "stories.json").write_text(
+        json.dumps({
+            "active_story_id": story_id,
+            "stories": {story_id: {"id": story_id, "name": "測試故事"}},
+        }, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+    (design_dir / "system_prompt.txt").write_text(
+        "你是GM。\n{character_state}\n{narrative_recap}\n{world_lore}\n{npc_profiles}\n{team_rules}\n{other_agents}\n{critical_facts}",
+        encoding="utf-8",
+    )
+    schema = {
+        "fields": [
+            {"key": "name", "type": "text"},
+            {"key": "current_phase", "type": "text"},
+            {"key": "reward_points", "type": "number"},
+            {"key": "current_status", "type": "text"},
+        ],
+        "lists": [
+            {"key": "inventory", "type": "map"},
+            {"key": "relationships", "type": "map"},
+        ],
+        "direct_overwrite_keys": ["current_phase", "current_status"],
+    }
+    (design_dir / "character_schema.json").write_text(json.dumps(schema, ensure_ascii=False), encoding="utf-8")
+    default_state = {
+        "name": "測試者",
+        "current_phase": "主神空間",
+        "reward_points": 1000,
+        "inventory": {},
+        "relationships": {},
+        "current_status": "待命",
+    }
+    (design_dir / "default_character_state.json").write_text(
+        json.dumps(default_state, ensure_ascii=False), encoding="utf-8"
+    )
+    (design_dir / "world_lore.json").write_text("[]", encoding="utf-8")
+    (design_dir / "parsed_conversation.json").write_text("[]", encoding="utf-8")
+
+    tree = {
+        "active_branch_id": "main",
+        "branches": {
+            "main": {"id": "main", "parent_branch_id": None, "branch_point_index": None, "name": "主線"},
+            "branch_blank_root": {
+                "id": "branch_blank_root",
+                "parent_branch_id": "main",
+                "branch_point_index": -1,
+                "blank": True,
+                "name": "空白根",
+            },
+            "branch_blank_child": {
+                "id": "branch_blank_child",
+                "parent_branch_id": "branch_blank_root",
+                "branch_point_index": 2,
+                "name": "空白子分支",
+            },
+        },
+    }
+    (story_dir / "timeline_tree.json").write_text(json.dumps(tree, ensure_ascii=False), encoding="utf-8")
+
+    for bid in ("main", "branch_blank_root", "branch_blank_child"):
+        bdir = story_dir / "branches" / bid
+        (bdir / "messages.json").write_text("[]", encoding="utf-8")
+        (bdir / "character_state.json").write_text(json.dumps(default_state, ensure_ascii=False), encoding="utf-8")
+        (bdir / "npcs.json").write_text("[]", encoding="utf-8")
+        (bdir / "dungeon_progress.json").write_text(
+            json.dumps({"history": [], "current_dungeon": None, "total_dungeons_completed": 0}, ensure_ascii=False),
+            encoding="utf-8",
+        )
+
+    return story_dir
+
+
+def _read_sse_events(resp) -> list[dict]:
+    body = b"".join(resp.response).decode("utf-8")
+    events = []
+    for line in body.splitlines():
+        if line.startswith("data: "):
+            events.append(json.loads(line[6:]))
+    return events
+
+
+def test_debug_session_uses_blank_root_unit(client, setup_story):
+    resp = client.get("/api/debug/session?branch_id=branch_blank_child")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["ok"] is True
+    assert data["debug_unit_id"] == "branch_blank_root"
+    assert data["target_branch_id"] == "branch_blank_child"
+
+
+def test_debug_chat_stream_parses_tags_and_persists_history(client, setup_story, monkeypatch):
+    def _fake_stream(*_args, **_kwargs):
+        yield ("text", "先做檢查。\n")
+        yield ("done", {
+            "response": (
+                "先做檢查。\n"
+                "<!--DEBUG_ACTION {\"type\":\"state_patch\",\"update\":{\"reward_points_delta\":50}} DEBUG_ACTION-->\n"
+                "<!--DEBUG_DIRECTIVE {\"instruction\":\"下一回合請確認主線任務狀態\"} DEBUG_DIRECTIVE-->"
+            ),
+            "usage": None,
+        })
+
+    monkeypatch.setattr(app_module, "call_claude_gm_stream", _fake_stream)
+
+    resp = client.post("/api/debug/chat/stream", json={
+        "branch_id": "branch_blank_child",
+        "user_message": "幫我檢查獎勵點和任務狀態",
+    })
+    assert resp.status_code == 200
+    events = _read_sse_events(resp)
+    done = next(e for e in events if e.get("type") == "done")
+    assert "先做檢查" in done["response"]
+    assert done["proposals"][0]["type"] == "state_patch"
+    assert done["directives"][0]["instruction"].startswith("下一回合")
+
+    chat_path = setup_story / "debug_units" / "branch_blank_root" / "chat.json"
+    chat = json.loads(chat_path.read_text(encoding="utf-8"))
+    assert len(chat) == 2
+    assert chat[0]["role"] == "user"
+    assert chat[1]["role"] == "assistant"
+
+
+def test_debug_apply_partial_success_and_audit(client, setup_story):
+    resp = client.post("/api/debug/apply", json={
+        "branch_id": "main",
+        "actions": [
+            {"type": "state_patch", "update": {"reward_points_delta": 100}},
+            {"type": "dungeon_patch", "progress_delta": 10},
+        ],
+        "directives": [
+            {"instruction": "下一回合請補主線完成提示"},
+        ],
+    })
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["ok"] is True
+    assert len(data["results"]) == 2
+    assert data["results"][0]["ok"] is True
+    assert data["results"][1]["ok"] is False
+    assert data["results"][1]["error"] == "no active dungeon"
+    assert data["directive_result"]["applied"] == 1
+    assert "1/2" in data["audit_summary"]
+
+    directive_path = setup_story / "branches" / "main" / "debug_directive.json"
+    assert directive_path.exists()
+
+    messages = json.loads((setup_story / "branches" / "main" / "messages.json").read_text(encoding="utf-8"))
+    assert any(m.get("message_type") == "debug_audit" for m in messages)
+
+
+def test_debug_undo_restores_snapshot_and_clears_directive(client, setup_story):
+    apply_resp = client.post("/api/debug/apply", json={
+        "branch_id": "main",
+        "actions": [
+            {"type": "state_patch", "update": {"reward_points_delta": 200}},
+            {"type": "world_day_set", "world_day": 12.5},
+        ],
+        "directives": [{"instruction": "下一回合請確認任務完成。"}],
+    })
+    assert apply_resp.status_code == 200
+
+    state_path = setup_story / "branches" / "main" / "character_state.json"
+    state_after_apply = json.loads(state_path.read_text(encoding="utf-8"))
+    assert state_after_apply["reward_points"] == 1200
+
+    undo_resp = client.post("/api/debug/undo", json={"branch_id": "main"})
+    assert undo_resp.status_code == 200
+    undo = undo_resp.get_json()
+    assert undo["ok"] is True
+    assert undo["restored"] is True
+
+    restored_state = json.loads(state_path.read_text(encoding="utf-8"))
+    assert restored_state["reward_points"] == 1000
+
+    directive_path = setup_story / "branches" / "main" / "debug_directive.json"
+    assert not directive_path.exists()

--- a/tests/test_debug_api.py
+++ b/tests/test_debug_api.py
@@ -180,6 +180,29 @@ def test_debug_chat_stream_parses_tags_and_persists_history(client, setup_story,
     assert chat[1]["role"] == "assistant"
 
 
+def test_debug_chat_stream_normalizes_action_without_type(client, setup_story, monkeypatch):
+    def _fake_stream(*_args, **_kwargs):
+        yield ("done", {
+            "response": (
+                "可先整理欄位。\n"
+                "<!--DEBUG_ACTION {\"update\":{\"reward_points_delta\":5}} DEBUG_ACTION-->"
+            ),
+            "usage": None,
+        })
+
+    monkeypatch.setattr(app_module, "call_claude_gm_stream", _fake_stream)
+
+    resp = client.post("/api/debug/chat/stream", json={
+        "branch_id": "main",
+        "user_message": "整理一下欄位",
+    })
+    assert resp.status_code == 200
+    events = _read_sse_events(resp)
+    done = next(e for e in events if e.get("type") == "done")
+    assert done["proposals"][0]["type"] == "state_patch"
+    assert done["proposals"][0]["update"]["reward_points_delta"] == 5
+
+
 def test_debug_apply_partial_success_and_audit(client, setup_story):
     resp = client.post("/api/debug/apply", json={
         "branch_id": "main",
@@ -206,6 +229,25 @@ def test_debug_apply_partial_success_and_audit(client, setup_story):
 
     messages = json.loads((setup_story / "branches" / "main" / "messages.json").read_text(encoding="utf-8"))
     assert any(m.get("message_type") == "debug_audit" for m in messages)
+
+
+def test_debug_apply_infers_state_patch_when_type_missing(client, setup_story):
+    resp = client.post("/api/debug/apply", json={
+        "branch_id": "main",
+        "actions": [
+            {"update": {"reward_points_delta": 10}},
+        ],
+        "directives": [],
+    })
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["ok"] is True
+    assert data["results"][0]["type"] == "state_patch"
+    assert data["results"][0]["ok"] is True
+
+    state_path = setup_story / "branches" / "main" / "character_state.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    assert state["reward_points"] == 1010
 
 
 def test_debug_undo_restores_snapshot_and_clears_directive(client, setup_story):

--- a/tests/test_debug_api.py
+++ b/tests/test_debug_api.py
@@ -203,6 +203,29 @@ def test_debug_chat_stream_normalizes_action_without_type(client, setup_story, m
     assert done["proposals"][0]["update"]["reward_points_delta"] == 5
 
 
+def test_debug_chat_stream_normalizes_action_with_patch_alias(client, setup_story, monkeypatch):
+    def _fake_stream(*_args, **_kwargs):
+        yield ("done", {
+            "response": (
+                "已整理。\n"
+                "<!--DEBUG_ACTION {\"action\":\"state_patch\",\"patch\":{\"reward_points_delta\":7}} DEBUG_ACTION-->"
+            ),
+            "usage": None,
+        })
+
+    monkeypatch.setattr(app_module, "call_claude_gm_stream", _fake_stream)
+
+    resp = client.post("/api/debug/chat/stream", json={
+        "branch_id": "main",
+        "user_message": "整理一下欄位",
+    })
+    assert resp.status_code == 200
+    events = _read_sse_events(resp)
+    done = next(e for e in events if e.get("type") == "done")
+    assert done["proposals"][0]["type"] == "state_patch"
+    assert done["proposals"][0]["update"]["reward_points_delta"] == 7
+
+
 def test_debug_apply_partial_success_and_audit(client, setup_story):
     resp = client.post("/api/debug/apply", json={
         "branch_id": "main",
@@ -248,6 +271,25 @@ def test_debug_apply_infers_state_patch_when_type_missing(client, setup_story):
     state_path = setup_story / "branches" / "main" / "character_state.json"
     state = json.loads(state_path.read_text(encoding="utf-8"))
     assert state["reward_points"] == 1010
+
+
+def test_debug_apply_infers_state_patch_from_action_patch_alias(client, setup_story):
+    resp = client.post("/api/debug/apply", json={
+        "branch_id": "main",
+        "actions": [
+            {"action": "state_patch", "patch": {"reward_points_delta": 11}},
+        ],
+        "directives": [],
+    })
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["ok"] is True
+    assert data["results"][0]["type"] == "state_patch"
+    assert data["results"][0]["ok"] is True
+
+    state_path = setup_story / "branches" / "main" / "character_state.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    assert state["reward_points"] == 1011
 
 
 def test_debug_undo_restores_snapshot_and_clears_directive(client, setup_story):

--- a/tests/test_debug_api.py
+++ b/tests/test_debug_api.py
@@ -254,6 +254,24 @@ def test_debug_apply_partial_success_and_audit(client, setup_story):
     assert any(m.get("message_type") == "debug_audit" for m in messages)
 
 
+def test_debug_apply_rejects_too_many_directives(client, setup_story):
+    resp = client.post("/api/debug/apply", json={
+        "branch_id": "main",
+        "actions": [],
+        "directives": [
+            {"instruction": f"指令 {i}"}
+            for i in range(app_module.DEBUG_APPLY_MAX_DIRECTIVES + 1)
+        ],
+    })
+    assert resp.status_code == 400
+    data = resp.get_json()
+    assert data["ok"] is False
+    assert data["error"] == f"too many directives (max {app_module.DEBUG_APPLY_MAX_DIRECTIVES})"
+
+    backup_path = setup_story / "debug_units" / "main" / "last_apply_backup.json"
+    assert not backup_path.exists()
+
+
 def test_debug_apply_infers_state_patch_when_type_missing(client, setup_story):
     resp = client.post("/api/debug/apply", json={
         "branch_id": "main",
@@ -318,3 +336,55 @@ def test_debug_undo_restores_snapshot_and_clears_directive(client, setup_story):
 
     directive_path = setup_story / "branches" / "main" / "debug_directive.json"
     assert not directive_path.exists()
+
+    messages = json.loads((setup_story / "branches" / "main" / "messages.json").read_text(encoding="utf-8"))
+    audits = [m for m in messages if m.get("message_type") == "debug_audit"]
+    assert len(audits) == 2
+    assert "已回滾 Debug 修正" in audits[-1]["content"]
+
+
+def test_debug_undo_rejects_invalid_backup_world_day_without_partial_restore(client, setup_story):
+    state_path = setup_story / "branches" / "main" / "character_state.json"
+    mutated_state = json.loads(state_path.read_text(encoding="utf-8"))
+    mutated_state["reward_points"] = 1337
+    state_path.write_text(json.dumps(mutated_state, ensure_ascii=False), encoding="utf-8")
+
+    directive_path = setup_story / "branches" / "main" / "debug_directive.json"
+    directive_path.write_text(json.dumps({
+        "instruction": "保留現有 directive",
+    }, ensure_ascii=False), encoding="utf-8")
+
+    backup_path = setup_story / "debug_units" / "main" / "last_apply_backup.json"
+    backup_path.parent.mkdir(parents=True, exist_ok=True)
+    backup_path.write_text(json.dumps({
+        "version": 1,
+        "created_at": "2026-03-07T00:00:00+00:00",
+        "debug_unit_id": "main",
+        "target_branch_id": "main",
+        "state_snapshot": {
+            "name": "測試者",
+            "current_phase": "主神空間",
+            "reward_points": 1000,
+            "inventory": {},
+            "relationships": {},
+            "current_status": "待命",
+        },
+        "npcs_snapshot": [],
+        "world_day": "oops",
+        "dungeon_progress_snapshot": {
+            "history": [],
+            "current_dungeon": None,
+            "total_dungeons_completed": 0,
+        },
+    }, ensure_ascii=False), encoding="utf-8")
+
+    undo_resp = client.post("/api/debug/undo", json={"branch_id": "main"})
+    assert undo_resp.status_code == 400
+    undo = undo_resp.get_json()
+    assert undo["ok"] is False
+    assert undo["error"] == "backup world_day invalid"
+
+    current_state = json.loads(state_path.read_text(encoding="utf-8"))
+    assert current_state["reward_points"] == 1337
+    assert directive_path.exists()
+    assert backup_path.exists()


### PR DESCRIPTION
## Summary
- implement Debug Panel V1 with server-owned debug chat history and global provider routing
- add debug apply/undo workflows for state, NPC, world_day, and dungeon with per-item results and full backup safety net
- add one-shot debug directive injection/consumption in GM flow and debug_audit messages excluded from prompt/compaction
- add frontend Debug panel UI (chat, selectable/editable proposals/directives, apply, undo) and debug_audit rendering in main chat
- add/extend tests for debug APIs, context injection ordering/consumption, compaction filtering, and route contracts
- update architecture/prompt/game mechanics/API/development docs

## Testing
- `python3 -m pytest tests/test_debug_api.py tests/test_context_injection.py tests/test_compaction.py tests/test_api_routes.py`
- `python3 -m pytest tests/test_state_update.py tests/test_extract_tags_async.py`
- `python3 -m py_compile app.py compaction.py`
- `node --check static/app.js`