### PR TITLE
Tighten lore query expansion

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,6 +11,7 @@ import threading
 import time
 import unicodedata
 import uuid
+from collections import Counter
 from datetime import datetime, timezone
 
 # Version — single source of truth in VERSION file
@@ -111,6 +112,20 @@ try:
     LLM_TRACE_RETENTION_DAYS = max(1, int(os.environ.get("LLM_TRACE_RETENTION_DAYS", "14")))
 except ValueError:
     LLM_TRACE_RETENTION_DAYS = 14
+BRANCH_LORE_SCORE_FLOOR = 0.02
+LORE_QUERY_MAX_RECENT_GM = 5
+LORE_QUERY_MAX_TERMS = 12
+_LORE_QUERY_STOP_TERMS = {
+    "主角", "隊長", "當前", "處境", "當前處境", "原本", "周圍", "似乎", "發出",
+    "已經", "東西", "能力", "完成", "利用", "作為", "白色", "空氣", "無數",
+    "瞬間", "以下行動", "素材", "級素材", "主神提示",
+}
+_LORE_QUERY_STOP_CHARS = set(
+    "的一是在有和就都也很嗎呢啊吧了我你他她它們這那個對於與及而並將被把讓來去會可要想說看做給著後前中上下內外高低新舊其並且或等得地"
+)
+_LORE_QUERY_INTERNAL_PUNCT = set("，,。！？!?；;：:、／/—-「」『』【】《》")
+_LORE_QUERY_QUOTED_RE = re.compile(r"[《「『【]([^\n]{2,20}?)[》」』】]")
+_LORE_QUERY_CJK_RE = re.compile(r"[\u4e00-\u9fff]{2,}")
 
 # Legacy paths — used only during migration
 CONVERSATION_PATH = os.path.join(BASE_DIR, "Grok_conversation.md")
@@ -1948,6 +1963,17 @@ def _search_branch_lore(story_id: str, branch_id: str, query: str,
     query_bgs = _bigrams(query)
     # Also use query words for non-CJK matching
     query_lower = query.lower()
+    expanded_query = query.splitlines()[-1] if "\n" in query else query
+    query_terms = []
+    seen_terms = set()
+    for raw_term in re.split(r"\s+", expanded_query):
+        if not _LORE_QUERY_CJK_RE.search(raw_term):
+            continue
+        term = _normalize_lore_query_term(raw_term)
+        if not term or term in seen_terms or _is_noisy_lore_query_term(term):
+            continue
+        seen_terms.add(term)
+        query_terms.append(term)
 
     # Dungeon scoping context
     current_dungeon = ""
@@ -1962,7 +1988,8 @@ def _search_branch_lore(story_id: str, branch_id: str, query: str,
         topic = e.get("topic", "")
         content = e.get("content", "")
         category = e.get("category", "")
-        text = f"{category} {topic} {content}"
+        subcategory = e.get("subcategory", "")
+        text = f"{category} {subcategory} {topic} {content}"
 
         score = 0.0
         text_bgs = _bigrams(text)
@@ -1973,12 +2000,15 @@ def _search_branch_lore(story_id: str, branch_id: str, query: str,
         # Boost for substring match in topic
         if query_lower and query_lower in topic.lower():
             score += 2.0
+        score += sum(1.5 for term in query_terms if term in topic)
+        score += sum(2.0 for term in query_terms if term in subcategory)
+        score += sum(0.6 for term in query_terms if term in content)
 
         # Penalize lore from other dungeons
-        if in_dungeon and category == "副本世界觀" and e.get("subcategory", "") != current_dungeon:
+        if in_dungeon and category == "副本世界觀" and subcategory != current_dungeon:
             score *= 0.1
 
-        if score > 0:
+        if score >= BRANCH_LORE_SCORE_FLOOR:
             scored.append((score, e))
 
     scored.sort(key=lambda x: -x[0])
@@ -1988,7 +2018,7 @@ def _search_branch_lore(story_id: str, branch_id: str, query: str,
     used_tokens = 0
     for _, e in scored:
         content = e.get("content", "")
-        est_tokens = len(content) // 2  # rough CJK estimate
+        est_tokens = len(content)  # CJK content is close to 1 token per char
         if used_tokens + est_tokens > token_budget and lines:
             break
         if len(content) > 1200:
@@ -2005,6 +2035,180 @@ def _search_branch_lore(story_id: str, branch_id: str, query: str,
     if not lines:
         return ""
     return "[相關分支設定]\n" + "\n".join(lines)
+
+
+def _normalize_lore_query_term(term: str) -> str:
+    return re.sub(r"\s+", "", term).strip("：:，,。！？!?、（）()[]{}").strip()
+
+
+def _is_noisy_lore_query_term(term: str) -> bool:
+    if len(term) < 2 or len(term) > 12:
+        return True
+    if term in _LORE_QUERY_STOP_TERMS:
+        return True
+    if any(ch in _LORE_QUERY_INTERNAL_PUNCT for ch in term):
+        return True
+    if term[0] in _LORE_QUERY_STOP_CHARS or term[-1] in _LORE_QUERY_STOP_CHARS:
+        return True
+    if all(ch in _LORE_QUERY_STOP_CHARS for ch in term):
+        return True
+    if len(term) == 2 and (term[0] in _LORE_QUERY_STOP_CHARS or term[1] in _LORE_QUERY_STOP_CHARS):
+        return True
+    return False
+
+
+def _split_quoted_lore_terms(term: str) -> list[str]:
+    parts = [term]
+    for sep in ("：", ":", "·", "／", "/", "—", "-"):
+        next_parts = []
+        for part in parts:
+            if sep not in part:
+                next_parts.append(part)
+                continue
+            next_parts.extend(piece for piece in part.split(sep) if piece)
+        parts = next_parts
+
+    normalized = []
+    seen = set()
+    for part in parts:
+        clean = _normalize_lore_query_term(part)
+        if clean and clean not in seen:
+            normalized.append(clean)
+            seen.add(clean)
+    return normalized
+
+
+def _extract_recent_lore_terms(recent_messages: list[dict] | None,
+                               limit: int = LORE_QUERY_MAX_TERMS) -> list[str]:
+    if not recent_messages:
+        return []
+
+    gm_messages = [
+        m.get("content", "")
+        for m in recent_messages
+        if m.get("role") in ("gm", "assistant") and isinstance(m.get("content"), str) and m.get("content")
+    ][-LORE_QUERY_MAX_RECENT_GM:]
+    if not gm_messages:
+        return []
+
+    scores = Counter()
+    for idx, text in enumerate(gm_messages):
+        recency_weight = idx + 1
+        latest_bonus = 2 if idx == len(gm_messages) - 1 else 0
+
+        for raw_term in _LORE_QUERY_QUOTED_RE.findall(text):
+            for term in _split_quoted_lore_terms(raw_term):
+                if not _is_noisy_lore_query_term(term):
+                    scores[term] += recency_weight * 10 + len(term) + latest_bonus * 4
+
+        for run in _LORE_QUERY_CJK_RE.findall(text):
+            for n in (3, 4):
+                for i in range(len(run) - n + 1):
+                    term = run[i:i + n]
+                    if _is_noisy_lore_query_term(term):
+                        continue
+                    scores[term] += recency_weight * (n - 1) + latest_bonus * (n - 1)
+
+    selected = []
+    for term, _ in sorted(scores.items(), key=lambda kv: (-kv[1], -len(kv[0]), kv[0])):
+        if any(term in kept for kept in selected if len(kept) > len(term)):
+            continue
+        selected.append(term)
+        if len(selected) >= limit:
+            break
+    return selected
+
+
+def _select_lore_npc_terms(
+    user_text: str,
+    recent_messages: list[dict] | None = None,
+    npcs: list[dict] | None = None,
+) -> list[str]:
+    if not npcs:
+        return []
+
+    recent_text = "\n".join(
+        m.get("content", "")
+        for m in (recent_messages or [])
+        if m.get("role") in ("gm", "assistant") and isinstance(m.get("content"), str)
+    )
+    context_text = f"{user_text}\n{recent_text}"
+    selected = []
+    seen = set()
+    for npc in npcs:
+        if not isinstance(npc, dict):
+            continue
+        name = _normalize_lore_query_term(str(npc.get("name", "")))
+        if (
+            not name
+            or name in seen
+            or _is_noisy_lore_query_term(name)
+            or name not in context_text
+        ):
+            continue
+        seen.add(name)
+        selected.append(name)
+    return selected
+
+
+def _extract_user_lore_terms(user_text: str, recent_messages: list[dict] | None = None) -> list[str]:
+    if not user_text:
+        return []
+
+    recent_text = "\n".join(
+        m.get("content", "")
+        for m in (recent_messages or [])
+        if m.get("role") in ("gm", "assistant") and isinstance(m.get("content"), str)
+    )
+    selected = []
+    seen = set()
+    for raw_term in re.split(r"\s+", user_text):
+        if not _LORE_QUERY_CJK_RE.search(raw_term):
+            continue
+        term = _normalize_lore_query_term(raw_term)
+        if (
+            not term
+            or term in seen
+            or _is_noisy_lore_query_term(term)
+            or (recent_text and term not in recent_text)
+        ):
+            continue
+        seen.add(term)
+        selected.append(term)
+    return selected
+
+
+def _build_lore_search_query(
+    user_text: str,
+    recent_messages: list[dict] | None = None,
+    npcs: list[dict] | None = None,
+    current_dungeon: str = "",
+) -> str:
+    extras = []
+    seen = set()
+
+    def _add(term: str):
+        clean = _normalize_lore_query_term(term)
+        if not clean or clean in seen or _is_noisy_lore_query_term(clean):
+            return
+        seen.add(clean)
+        extras.append(clean)
+
+    if current_dungeon:
+        _add(current_dungeon)
+
+    for npc_name in _select_lore_npc_terms(user_text, recent_messages=recent_messages, npcs=npcs):
+        _add(npc_name)
+
+    for term in _extract_user_lore_terms(user_text, recent_messages=recent_messages):
+        _add(term)
+
+    for term in _extract_recent_lore_terms(recent_messages):
+        _add(term)
+
+    if not extras:
+        return user_text
+    return user_text + "\n" + " ".join(extras)
 
 
 def _get_branch_lore_toc(story_id: str, branch_id: str) -> str:
@@ -4411,6 +4615,7 @@ def _build_augmented_message(
     story_id: str, branch_id: str, user_text: str,
     character_state: dict | None = None,
     npcs: list[dict] | None = None,
+    recent_messages: list[dict] | None = None,
     turn_count: int = 0,
     current_index: int | None = None,
 ) -> tuple[str, dict | None]:
@@ -4430,14 +4635,23 @@ def _build_augmented_message(
             "status": character_state.get("current_status", ""),
             "dungeon": character_state.get("current_dungeon", ""),
         }
+    if npcs is None:
+        npcs = _load_npcs(story_id, branch_id)
+
+    lore_query = _build_lore_search_query(
+        user_text,
+        recent_messages=recent_messages,
+        npcs=npcs,
+        current_dungeon=(character_state or {}).get("current_dungeon", ""),
+    )
 
     parts = []
     # Search base lore (via lore.db indexed search)
-    lore = search_relevant_lore(story_id, user_text, context=lore_context)
+    lore = search_relevant_lore(story_id, lore_query, context=lore_context)
     if lore:
         parts.append(lore)
     # Search branch lore (linear CJK bigram search, smaller dataset)
-    branch_lore = _search_branch_lore(story_id, branch_id, user_text, context=lore_context)
+    branch_lore = _search_branch_lore(story_id, branch_id, lore_query, context=lore_context)
     if branch_lore:
         parts.append(branch_lore)
     if not is_blank:
@@ -4454,15 +4668,7 @@ def _build_augmented_message(
 
     # State RAG — on-demand retrieval for inventory/skills/npcs/relations/missions/systems.
     if character_state:
-        all_npcs: list[dict]
-        if npcs is None:
-            all_npcs = _load_npcs(story_id, branch_id, include_archived=True)
-            npcs = [
-                n for n in all_npcs
-                if isinstance(n, dict) and _normalize_npc_lifecycle_status(n.get("lifecycle_status")) != "archived"
-            ]
-        else:
-            all_npcs = _load_npcs(story_id, branch_id, include_archived=True)
+        all_npcs = _load_npcs(story_id, branch_id, include_archived=True)
         must_include = _extract_state_must_include_keys(user_text, character_state, all_npcs)
         state_block = search_state_entries(
             story_id,
@@ -4753,7 +4959,7 @@ def api_send():
     t0 = time.time()
     tc = sum(1 for m in full_timeline if m.get("role") == "user")
     augmented_text, dice_result = _build_augmented_message(
-        story_id, branch_id, user_text, state, npcs=npcs, turn_count=tc,
+        story_id, branch_id, user_text, state, npcs=npcs, recent_messages=recent, turn_count=tc,
         current_index=player_msg["index"],
     )
     if dice_result:
@@ -4899,7 +5105,7 @@ def api_send_stream():
     )
     tc = sum(1 for m in full_timeline if m.get("role") == "user")
     augmented_text, dice_result = _build_augmented_message(
-        story_id, branch_id, user_text, state, npcs=npcs, turn_count=tc,
+        story_id, branch_id, user_text, state, npcs=npcs, recent_messages=recent, turn_count=tc,
         current_index=player_msg["index"],
     )
     if dice_result:
@@ -5383,7 +5589,7 @@ def api_branches_edit():
     t0 = time.time()
     tc = sum(1 for m in full_timeline if m.get("role") == "user")
     augmented_edit, dice_result = _build_augmented_message(
-        story_id, branch_id, edited_message, state, npcs=npcs, turn_count=tc,
+        story_id, branch_id, edited_message, state, npcs=npcs, recent_messages=recent, turn_count=tc,
         current_index=user_msg_index,
     )
     if dice_result:
@@ -5558,7 +5764,7 @@ def api_branches_edit_stream():
     )
     tc = sum(1 for m in full_timeline if m.get("role") == "user")
     augmented_edit, dice_result = _build_augmented_message(
-        story_id, branch_id, edited_message, state, npcs=npcs, turn_count=tc,
+        story_id, branch_id, edited_message, state, npcs=npcs, recent_messages=recent, turn_count=tc,
         current_index=user_msg_index,
     )
     if dice_result:
@@ -5736,7 +5942,7 @@ def api_branches_regenerate():
     t0 = time.time()
     tc = sum(1 for m in full_timeline if m.get("role") == "user")
     augmented_regen, dice_result = _build_augmented_message(
-        story_id, branch_id, user_msg_content, state, npcs=npcs, turn_count=tc,
+        story_id, branch_id, user_msg_content, state, npcs=npcs, recent_messages=recent, turn_count=tc,
         current_index=branch_point_index,
     )
     log.info("  context_search: %.0fms", (time.time() - t0) * 1000)
@@ -5893,7 +6099,7 @@ def api_branches_regenerate_stream():
     )
     tc = sum(1 for m in full_timeline if m.get("role") == "user")
     augmented_regen, dice_result = _build_augmented_message(
-        story_id, branch_id, user_msg_content, state, npcs=npcs, turn_count=tc,
+        story_id, branch_id, user_msg_content, state, npcs=npcs, recent_messages=recent, turn_count=tc,
         current_index=branch_point_index,
     )
 

--- a/doc/prompt_design.md
+++ b/doc/prompt_design.md
@@ -71,6 +71,16 @@
 9. `---`
 10. 原始玩家輸入
 
+補充：
+
+- lore 檢索 query 不是只用原始玩家輸入。
+  - 會先保留原始玩家輸入。
+  - 再附加 `current_dungeon`。
+  - 再附加「最近幾則 GM 回覆或玩家輸入中明確提到」的 active NPC 名稱。
+  - 再附加 recent GM 回覆中的高訊號 CJK terms（優先保留副本名、NPC 名、事件名、術式/道具名）。
+- `[相關世界設定]` 會用這個 expanded query 做 keyword + embedding 混合排序，並套用最低 keyword/RRF 分數門檻，避免弱命中條目塞滿 token budget。
+- `[相關分支設定]` 會用同一份 expanded query 做 normalized bigram overlap 搜尋，並額外考慮 query terms 對 `topic/subcategory/content` 的命中；budget 估算以 CJK 約 1 char ≈ 1 token 計，避免低相關的舊分支設定過量注入。
+
 ### 2.5 戰力等級一致性（Tier Consistency）
 
 - `system_prompt.txt` 內新增「戰力等級敘事指南（演出落地）」：五大等級 D/C/B/A/S 的具體演出維度與反面檢查。

--- a/lore_db.py
+++ b/lore_db.py
@@ -26,6 +26,8 @@ _INLINE_META_RE = re.compile(r"\s*\[(?:tag|source):\s*[^\]]*\]")
 EMBEDDING_DIM = 768
 RRF_K = 60  # Reciprocal Rank Fusion constant
 DEFAULT_TOKEN_BUDGET = 3000  # ~3000 CJK chars ≈ 3000 tokens
+KEYWORD_SCORE_FLOOR = 3
+RRF_SCORE_FLOOR = 0.012
 
 
 def _db_path(story_id: str) -> str:
@@ -531,7 +533,7 @@ def search_lore(story_id: str, query: str, limit: int = 5) -> list[dict]:
                     score += 5
                 if kw in row['content']:
                     score += 1
-        if score > 0:
+        if score >= KEYWORD_SCORE_FLOOR:
             scored.append({
                 "id": row["id"],
                 "category": row["category"],
@@ -684,6 +686,8 @@ def search_hybrid(
     results = []
     tokens_used = 0
     for entry_id in sorted_ids:
+        if rrf_scores[entry_id] < RRF_SCORE_FLOOR:
+            break
         entry = candidates[entry_id]
         # Estimate: 1 CJK char ≈ 1 token, cap at 1200 (content is truncated at injection)
         content_len = min(len(entry.get("content", "")), 1200)

--- a/tests/test_branch_lore.py
+++ b/tests/test_branch_lore.py
@@ -364,6 +364,55 @@ class TestSearchBranchLore:
         headers = [line for line in result.split("\n") if line.startswith("####")]
         assert len(headers) < 20  # Budget should limit output
 
+    def test_token_budget_uses_cjk_char_length(self, story_id, setup_story):
+        app_module._save_branch_lore(story_id, "main", [
+            {"category": "test", "topic": "設定A", "content": "設" * 220},
+            {"category": "test", "topic": "設定B", "content": "設" * 220},
+        ])
+        result = app_module._search_branch_lore(story_id, "main", "設定", token_budget=300)
+        headers = [line for line in result.split("\n") if line.startswith("####")]
+        assert len(headers) == 1
+
+    def test_ranks_stronger_bigram_overlap_ahead_of_weak_match(self, story_id, setup_story):
+        app_module._save_branch_lore(story_id, "main", [
+            {"category": "test", "topic": "弱命中", "content": "只有白鴉這一小段"},
+            {"category": "test", "topic": "強命中", "content": "白鴉提出獄門疆定位測試，要求封印神談判條件與座標校準"},
+        ])
+        result = app_module._search_branch_lore(
+            story_id,
+            "main",
+            "白鴉獄門疆封印神談判定位測試座標校準",
+            token_budget=60,
+        )
+        headers = [line for line in result.split("\n") if line.startswith("####")]
+        assert headers
+        assert "強命中" in headers[0]
+
+    def test_expanded_terms_boost_current_dungeon_entry(self, story_id, setup_story):
+        app_module._save_branch_lore(story_id, "main", [
+            {
+                "category": "副本世界觀",
+                "subcategory": "咒術迴戰",
+                "topic": "澀谷事變",
+                "content": "獄門疆與神王小隊的行動線索都在這裡。",
+            },
+            {
+                "category": "體系",
+                "subcategory": "萬象召喚",
+                "topic": "門之鑰：媒介定位",
+                "content": "舊裝備線的操作筆記。",
+            },
+        ])
+        result = app_module._search_branch_lore(
+            story_id,
+            "main",
+            "我願意提供 獄門疆 的情報\n咒術迴戰 白鴉 神王小隊 門之鑰",
+            context={"phase": "主神空間", "status": "", "dungeon": "咒術迴戰"},
+        )
+        headers = [line for line in result.split("\n") if line.startswith("####")]
+        assert headers
+        assert "澀谷事變" in headers[0]
+
     def test_no_match_returns_empty(self, story_id, setup_story):
         """Query with no match returns empty string."""
         app_module._save_branch_lore(story_id, "main", [
@@ -439,6 +488,60 @@ class TestBuildLoreTextWithBranch:
 
 
 class TestBuildAugmentedMessageWithBranchLore:
+    def test_select_lore_npc_terms_only_keeps_mentioned_active_npcs(self):
+        recent = [
+            {"role": "gm", "content": "白鴉已經到了，神王小隊也在附近待命。"},
+        ]
+        npcs = [
+            {"name": "白鴉"},
+            {"name": "小琳"},
+            {"name": "邁特凱"},
+        ]
+        terms = app_module._select_lore_npc_terms(
+            "我去找白鴉談獄門疆",
+            recent_messages=recent,
+            npcs=npcs,
+        )
+        assert terms == ["白鴉"]
+
+    def test_extract_user_lore_terms_requires_recent_overlap(self):
+        recent = [
+            {"role": "gm", "content": "白鴉提到獄門疆，但還沒談到封印神。"},
+        ]
+        terms = app_module._extract_user_lore_terms(
+            "我可以提供 獄門疆 的情報，封印神 的時候算我一個",
+            recent_messages=recent,
+        )
+        assert terms == ["獄門疆"]
+
+    @mock.patch("app._extract_recent_lore_terms", return_value=["神王小隊", "澀谷事變"])
+    @mock.patch("app.search_relevant_lore", return_value="[相關世界設定]\n咒術迴戰")
+    @mock.patch("app.search_relevant_events", return_value="")
+    @mock.patch("app.get_recent_activities", return_value="")
+    @mock.patch("app.is_gm_command", return_value=False)
+    @mock.patch("app.roll_fate", return_value={"outcome": "順遂"})
+    @mock.patch("app.format_dice_context", return_value="[命運走向] 順遂")
+    def test_build_lore_search_query_expands_with_recent_context(
+        self, mock_fmt, mock_roll, mock_gm, mock_act, mock_evt, mock_lore, mock_recent,
+        story_id, setup_story
+    ):
+        text, _ = app_module._build_augmented_message(
+            story_id,
+            "main",
+            "我會提供 獄門疆 的情報",
+            {"current_phase": "主神空間", "current_dungeon": "咒術迴戰"},
+            npcs=[{"name": "白鴉"}, {"name": "邁特凱"}],
+            recent_messages=[{"role": "gm", "content": "白鴉與神王小隊準備進入澀谷事變。"}],
+        )
+        assert "[相關世界設定]" in text
+        called_query = mock_lore.call_args.args[1]
+        assert "咒術迴戰" in called_query
+        assert "白鴉" in called_query
+        assert "獄門疆" in called_query
+        assert "神王小隊" in called_query
+        assert "澀谷事變" in called_query
+        assert "邁特凱" not in called_query
+
     @mock.patch("app.search_relevant_lore", return_value="[相關世界設定]\n基因鎖")
     @mock.patch("app.search_relevant_events", return_value="")
     @mock.patch("app.get_recent_activities", return_value="")

--- a/tests/test_lore_db.py
+++ b/tests/test_lore_db.py
@@ -299,7 +299,11 @@ class TestSearchLore:
         # Pure English query → uses full string as keyword
         # "T病毒" has CJK: "T病毒" → bigrams: "病毒"
         results = lore_db.search_lore(story_id, "T病毒")
-        assert len(results) > 0
+        assert results == []
+
+    def test_filters_single_content_bigram_noise(self, story_id, setup_lore):
+        results = lore_db.search_lore(story_id, "病毒")
+        assert results == []
 
 
 # ===================================================================
@@ -317,7 +321,7 @@ class TestSearchHybrid:
 
     def test_token_budget_respected(self, story_id, setup_lore):
         # With a very small budget, should limit results
-        results = lore_db.search_hybrid(story_id, "的", token_budget=100)
+        results = lore_db.search_hybrid(story_id, "基因鎖", token_budget=100)
         total_tokens = sum(
             min(len(r.get("content", "")), 1200) + len(r.get("topic", "")) + 20
             for r in results
@@ -352,10 +356,17 @@ class TestSearchHybrid:
         results = lore_db.search_hybrid(story_id, "zzz_no_match")
         assert results == []
 
+    def test_rrf_floor_drops_penalized_cross_dungeon_tail(self, story_id, setup_lore_with_subcategory):
+        context = {"phase": "副本中", "status": "", "dungeon": "咒怨"}
+        results = lore_db.search_hybrid(story_id, "副本目標", context=context)
+        topics = [r["topic"] for r in results]
+        assert "咒怨" in topics
+        assert "生化危機" not in topics
+
     def test_dungeon_scoping_penalizes_other_dungeons(self, story_id, setup_lore_with_subcategory):
         """When in 咒怨 dungeon, 生化危機 entries should be penalized."""
         context = {"phase": "副本中", "status": "", "dungeon": "咒怨"}
-        results = lore_db.search_hybrid(story_id, "副本", context=context)
+        results = lore_db.search_hybrid(story_id, "副本目標", context=context)
         assert len(results) > 0
         # 咒怨 should rank before 生化危機
         topics = [r["topic"] for r in results]
@@ -365,7 +376,7 @@ class TestSearchHybrid:
     def test_dungeon_scoping_no_penalty_without_dungeon(self, story_id, setup_lore_with_subcategory):
         """Without dungeon context, no penalization."""
         context = {"phase": "副本中", "status": "", "dungeon": ""}
-        results = lore_db.search_hybrid(story_id, "副本", context=context)
+        results = lore_db.search_hybrid(story_id, "副本目標", context=context)
         # Both should appear without strong penalization
         topics = [r["topic"] for r in results]
         assert "咒怨" in topics or "生化危機" in topics
@@ -373,7 +384,7 @@ class TestSearchHybrid:
     def test_dungeon_scoping_no_penalty_in_main_space(self, story_id, setup_lore_with_subcategory):
         """In 主神空間 (no 副本 in phase), no dungeon penalty even if dungeon set."""
         context = {"phase": "主神空間", "status": "", "dungeon": "咒怨"}
-        results = lore_db.search_hybrid(story_id, "副本", context=context)
+        results = lore_db.search_hybrid(story_id, "副本目標", context=context)
         topics = [r["topic"] for r in results]
         # 生化危機 should NOT be heavily penalized since we're not in a dungeon phase
         assert "生化危機" in topics or len(results) > 0


### PR DESCRIPTION
## Summary
- tighten lore query expansion so lore search is driven by recent GM context instead of raw user text alone
- keep the existing keyword/RRF floors and branch token estimate fix, but lower branch floor pressure and add branch-side query-term boosts
- add regression tests for expanded-query construction and branch lore ranking

## Root Cause
Lore injection precision was poor because:
- branch lore used a loose bigram search with an underestimated token budget
- base lore relied on short raw user queries, so semantic drift could outrank the current arc
- even after adding score floors, recent-arc signals were still too weak unless the query explicitly carried current dungeon / NPC / arc terms

## What Changed
### Query expansion
- build lore search queries from:
  - raw user text
  - `current_dungeon`
  - active NPC names that are actually mentioned in recent GM/user context
  - user terms that also appear in recent GM context (for example `獄門疆`)
  - high-signal CJK terms extracted from recent GM replies
- keep extraction deterministic; no extra LLM call

### Branch lore search
- keep the corrected token estimate (`len(content)`)
- keep a conservative branch score floor (`0.02`)
- boost matches against expanded query terms in branch lore `topic`, `subcategory`, and `content`
- use only the expanded query tail for exact-match boosts, so raw user prose does not pollute term matching

### Base lore search
- keep the keyword score floor and RRF floor from the earlier precision fix

## Validation
- `pytest -q tests/test_branch_lore.py tests/test_lore_db.py`
- `pytest -q tests/test_api_routes.py tests/test_context_injection.py`

## Real Sample Smoke Check
On the real `branch_e1cfb405` trace in `story-prod`:
- expanded query now includes current-arc signals such as `咒術迴戰`, `白鴉`, `獄門疆`, `神王小隊`
- base lore top result shifts to `副本世界觀/咒術迴戰：介紹`
- branch lore now surfaces `副本世界觀/咒術迴戰：澀谷事變` inside the injected set instead of dropping all dungeon-specific entries

## Residual Risk
This improves precision materially, but branch lore still carries some older item/system terms when recent GM replies heavily discuss them. If we want another pass, the next lever is stronger arc scoping or per-message recent-term selection.
