### PR TITLE
Reconcile dungeon progress on narrative state transitions

### DIFF
--- a/app.py
+++ b/app.py
@@ -95,6 +95,7 @@ from dungeon_system import (
     ensure_dungeon_templates, initialize_dungeon_progress, archive_current_dungeon,
     update_dungeon_progress, update_dungeon_area, validate_dungeon_progression,
     build_dungeon_context, copy_dungeon_progress, get_dungeon_progress_snapshot,
+    reconcile_dungeon_entry, reconcile_dungeon_exit,
     _load_dungeon_templates, _load_dungeon_template, _load_dungeon_progress,
     _parse_rank,
 )
@@ -3343,12 +3344,16 @@ def _normalize_state_async(story_id: str, branch_id: str, update: dict, known_ke
                 return
             log.info("    state_normalize: remapped %d unknown keys, re-applying", len(unknown))
             norm_schema = _load_character_schema(story_id)
+            pre_state = _load_character_state(story_id, branch_id)
             normalized = _run_state_gate(
                 normalized, norm_schema,
-                _load_character_state(story_id, branch_id),
+                pre_state,
                 label="state_gate(normalize)", allow_llm=False,
                 story_id=story_id, branch_id=branch_id)
             _apply_state_update_inner(story_id, branch_id, normalized, norm_schema)
+            post_state = _load_character_state(story_id, branch_id)
+            reconcile_dungeon_entry(story_id, branch_id, pre_state, post_state)
+            reconcile_dungeon_exit(story_id, branch_id, pre_state, post_state)
         except Exception as e:
             log.info("    state_normalize: failed (%s), skipping", e)
 
@@ -4157,8 +4162,9 @@ def _apply_state_update(story_id: str, branch_id: str, update: dict):
 
     1. Runs deterministic validation gate (if enabled)
     2. Immediately applies the (possibly sanitized) update
-    3. Validates dungeon growth constraints (hard cap)
-    4. Kicks off background LLM normalization for non-standard fields
+    3. Reconciles dungeon entry/exit for narrative-path transitions
+    4. Validates dungeon growth constraints (hard cap)
+    5. Kicks off background LLM normalization for non-standard fields
     """
     schema = _load_character_schema(story_id)
 
@@ -4175,10 +4181,19 @@ def _apply_state_update(story_id: str, branch_id: str, update: dict):
     # Apply immediately
     _apply_state_update_inner(story_id, branch_id, update, schema)
 
-    # Hard constraint validation (dungeon system)
     new_state = _load_character_state(story_id, branch_id)
+
+    # Initialize dungeon progress before validation so entry turns see the budget.
+    reconcile_dungeon_entry(story_id, branch_id, old_state, new_state)
+
+    # Hard constraint validation (dungeon system)
     validate_dungeon_progression(story_id, branch_id, new_state, old_state)
+
+    # Archive old dungeon after validation so exit turns record capped growth.
+    reconcile_dungeon_exit(story_id, branch_id, old_state, new_state)
+
     _save_json(_story_character_state_path(story_id, branch_id), new_state)
+    _sync_state_db_from_state(story_id, branch_id, new_state)
 
     # Background: normalize non-standard fields and re-apply
     _normalize_state_async(story_id, branch_id, update, _get_schema_known_keys(schema))

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -129,6 +129,7 @@ Browser (static/app.js, templates/index.html)
 - 直接從 GM 回覆內的顯式 tag 解析並套用。
 - 優先保證即時可見狀態。
 - `_apply_state_update_inner()` 套用 canonical `character_state.json` 後，會同步 `replace_categories_batch(...)` 更新 `state.db`（inventory/ability/relationship/mission/system）。
+- wrapper `_apply_state_update()` 會額外處理 `current_dungeon` reconciliation：把 narrative/state 路徑的副本轉場收斂到 `dungeon_progress.json`，並在 growth cap 後重新同步 state.db。
 - `_save_npc()` 與 `/api/npcs/<id> DELETE` 會同步 upsert/delete `state.db` 的 npc 類別，確保索引與 `npcs.json` 一致。
 
 ### 非同步抽取（背景）

--- a/doc/game_mechanics.md
+++ b/doc/game_mechanics.md
@@ -107,6 +107,8 @@
 
 `_apply_state_update()` 內會呼叫 `validate_dungeon_progression()`：
 
+- 若 `current_dungeon` 是透過敘事/state 路徑被寫入，而不是 `/api/dungeon/enter`，系統會先做 reconciliation，自動補齊 `dungeon_progress.json`
+- 進入副本的 reconciliation 發生在 validation 前；離開/切換副本的 archive 發生在 validation 後
 - 限制每副本可提升的 rank / gene lock budget
 - 超限會被 cap 並回寫
 
@@ -291,6 +293,15 @@
 - `60% ~ 99%`：可提前回歸，獎勵 50%
 - `100%`：正常回歸
 - 最終獎勵會套 difficulty scaling
+
+### 11.4 Narrative Path Reconciliation
+
+- 顯式 API 路徑（`/api/dungeon/enter` / `/api/dungeon/return`）仍是主路徑
+- safety net 會監看 `character_state.current_dungeon` 的轉場：
+  - `"" -> "副本名"`：若 progress 尚未 active，依模板名稱對照自動初始化
+  - `"副本名" -> ""`：在 final-turn validation 後自動 archive
+  - `"副本A" -> "副本B"`：先 archive 舊副本，再初始化新副本
+- 如果副本名稱找不到 template，reconciliation 只記 log，不會憑空建立進度
 
 ---
 

--- a/doc/prompt_design.md
+++ b/doc/prompt_design.md
@@ -135,6 +135,7 @@
 ### 3.4 State Index 同步點
 
 - canonical state 寫入最終匯集點是 `_apply_state_update_inner()`；套用後會同步 state.db 非 NPC 類別。
+- `_apply_state_update()` 若偵測到 `current_dungeon` 轉場，會額外 reconciliation `dungeon_progress.json`；validation 後的最終 state 也會再同步一次 state.db，避免 growth cap 後索引殘留舊值。
 - NPC 寫入透過 `_save_npc()` 同步 state.db（含 `lifecycle_status` / `archived_reason` 與 `NPC|ARCHIVED` tag）；手動刪除 NPC（`DELETE /api/npcs/<id>`）也會同步刪除索引。
 - fork/edit/regen/blank/merge 分支操作會用 snapshot 對應的 state/npcs 重建 state.db，避免「分支時間點」與「索引內容」不一致。
 
@@ -158,6 +159,7 @@
 - plan 會注入「上一輪 gm_plan 摘要」讓模型可延續或重寫；`must_payoff` 會依 `event_title` relink 到當前分支 active events
 - NPC 提取支援 `tier` 欄位；若既有 NPC 本回合無法判定 tier，應省略該欄位（不要用 null 覆蓋）
 - state 優先走 `state_ops`（set/delta/map_upsert/map_remove/list_add/list_remove），fallback 才用 legacy `state`
+- async state / normalize / cleanup 若把 `current_dungeon` 寫進 canonical state，也會透過 reconciliation 自動補齊或歸檔 `dungeon_progress.json`
 - time 有上限（單次最多 30 天）
 - dungeon 進度提取時會給 node id 對照
 

--- a/dungeon_system.py
+++ b/dungeon_system.py
@@ -80,6 +80,18 @@ def _load_dungeon_template(story_id: str, dungeon_id: str) -> Optional[dict]:
     return None
 
 
+def resolve_dungeon_id_by_name(story_id: str, display_name: str) -> Optional[str]:
+    """Resolve a dungeon display name (e.g. 火影忍者) to template id (e.g. naruto)."""
+    target = (display_name or "").strip()
+    if not target:
+        return None
+    templates = _load_dungeon_templates(story_id)
+    for dungeon in templates.get("dungeons", []):
+        if (dungeon.get("name") or "").strip() == target:
+            return dungeon.get("id")
+    return None
+
+
 def _load_dungeon_progress(story_id: str, branch_id: str) -> Optional[dict]:
     """Load dungeon progress for a branch."""
     path = os.path.join(_branch_dir(story_id, branch_id), "dungeon_progress.json")
@@ -160,13 +172,28 @@ def _format_gene_lock(percentage: int) -> str:
 
 # ========== Dungeon Lifecycle ==========
 
-def initialize_dungeon_progress(story_id: str, branch_id: str, dungeon_id: str):
+def _copy_state_override(state_override: Optional[dict]) -> Optional[dict]:
+    if isinstance(state_override, dict):
+        return copy.deepcopy(state_override)
+    return None
+
+
+def _current_dungeon_name(state: Optional[dict]) -> str:
+    return str((state or {}).get("current_dungeon") or "").strip()
+
+
+def initialize_dungeon_progress(
+    story_id: str,
+    branch_id: str,
+    dungeon_id: str,
+    state_override: Optional[dict] = None,
+):
     """Initialize dungeon progress when entering a dungeon."""
     template = _load_dungeon_template(story_id, dungeon_id)
     if not template:
         raise ValueError(f"Dungeon template not found: {dungeon_id}")
 
-    state = _load_character_state(story_id, branch_id)
+    state = _copy_state_override(state_override) or _load_character_state(story_id, branch_id)
 
     # Find initial areas (status = "discovered")
     initial_areas = [a["id"] for a in template.get("areas", []) if a.get("initial_status") == "discovered"]
@@ -209,7 +236,12 @@ def initialize_dungeon_progress(story_id: str, branch_id: str, dungeon_id: str):
     log.info(f"Initialized dungeon progress: {story_id}/{branch_id} → {dungeon_id}")
 
 
-def archive_current_dungeon(story_id: str, branch_id: str, exit_reason: str = "normal"):
+def archive_current_dungeon(
+    story_id: str,
+    branch_id: str,
+    exit_reason: str = "normal",
+    state_override: Optional[dict] = None,
+):
     """Archive current dungeon to history when returning to Main God Space."""
     progress = _load_dungeon_progress(story_id, branch_id)
     if not progress or not progress.get("current_dungeon"):
@@ -217,7 +249,7 @@ def archive_current_dungeon(story_id: str, branch_id: str, exit_reason: str = "n
         return
 
     current = progress.pop("current_dungeon")
-    state = _load_character_state(story_id, branch_id)
+    state = _copy_state_override(state_override) or _load_character_state(story_id, branch_id)
 
     history_entry = {
         "dungeon_id": current["dungeon_id"],
@@ -238,6 +270,69 @@ def archive_current_dungeon(story_id: str, branch_id: str, exit_reason: str = "n
     progress["total_dungeons_completed"] = len(progress["history"])
     _save_dungeon_progress(story_id, branch_id, progress)
     log.info(f"Archived dungeon: {current['dungeon_id']} (reason: {exit_reason})")
+
+
+def reconcile_dungeon_entry(story_id: str, branch_id: str, old_state: dict, new_state: dict):
+    """Initialize progress when state transitions into a dungeon outside explicit APIs."""
+    old_dungeon = _current_dungeon_name(old_state)
+    new_dungeon = _current_dungeon_name(new_state)
+    if not new_dungeon or new_dungeon == old_dungeon:
+        return
+
+    progress = _load_dungeon_progress(story_id, branch_id)
+    if progress and progress.get("current_dungeon"):
+        return
+
+    dungeon_id = resolve_dungeon_id_by_name(story_id, new_dungeon)
+    if not dungeon_id:
+        log.info("reconcile_entry: no template for %r, skipping", new_dungeon)
+        return
+
+    try:
+        initialize_dungeon_progress(
+            story_id,
+            branch_id,
+            dungeon_id,
+            state_override=old_state,
+        )
+    except Exception:
+        log.warning("reconcile_entry: failed to init %s", dungeon_id, exc_info=True)
+
+
+def reconcile_dungeon_exit(story_id: str, branch_id: str, old_state: dict, new_state: dict):
+    """Archive old progress after validation and initialize the new dungeon on switch."""
+    old_dungeon = _current_dungeon_name(old_state)
+    new_dungeon = _current_dungeon_name(new_state)
+    if old_dungeon == new_dungeon:
+        return
+
+    if old_dungeon:
+        progress = _load_dungeon_progress(story_id, branch_id)
+        if progress and progress.get("current_dungeon"):
+            archive_current_dungeon(
+                story_id,
+                branch_id,
+                exit_reason="narrative",
+                state_override=new_state,
+            )
+
+    if new_dungeon:
+        progress = _load_dungeon_progress(story_id, branch_id)
+        if progress and progress.get("current_dungeon"):
+            return
+        dungeon_id = resolve_dungeon_id_by_name(story_id, new_dungeon)
+        if not dungeon_id:
+            log.info("reconcile_exit: no template for %r, skipping", new_dungeon)
+            return
+        try:
+            initialize_dungeon_progress(
+                story_id,
+                branch_id,
+                dungeon_id,
+                state_override=new_state,
+            )
+        except Exception:
+            log.warning("reconcile_exit: failed to init %s", dungeon_id, exc_info=True)
 
 
 # ========== Progress Updates (called by async tag extraction) ==========

--- a/state_cleanup.py
+++ b/state_cleanup.py
@@ -11,6 +11,7 @@ import threading
 import time
 
 from compaction import get_recap_text
+from dungeon_system import reconcile_dungeon_entry, reconcile_dungeon_exit
 from event_db import get_active_events, get_event_title_map, update_event_status
 
 log = logging.getLogger("rpg")
@@ -410,7 +411,11 @@ def _run_cleanup_core(story_id: str, branch_id: str) -> dict:
                 "removed_inventory": 0, "removed_abilities": 0, "added_abilities": 0,
                 "updated_systems": 0, "clean_relationships": 0}
 
+    pre_cleanup_state = app_module._load_character_state(story_id, branch_id)
     summary = _apply_cleanup_operations(story_id, branch_id, ops)
+    post_cleanup_state = app_module._load_character_state(story_id, branch_id)
+    reconcile_dungeon_entry(story_id, branch_id, pre_cleanup_state, post_cleanup_state)
+    reconcile_dungeon_exit(story_id, branch_id, pre_cleanup_state, post_cleanup_state)
     log.info(
         "state_cleanup: applied archived=%d merged=%d resolved=%d"
         " removed_inv=%d removed_abilities=%d added_abilities=%d"

--- a/tests/test_dungeon_reconciliation.py
+++ b/tests/test_dungeon_reconciliation.py
@@ -1,0 +1,356 @@
+import json
+
+import app as app_module
+import dungeon_system
+import event_db
+import llm_bridge
+import state_cleanup
+import state_db
+import world_timer
+
+
+STORY_ID = "test_story"
+BRANCH_ID = "main"
+
+SCHEMA = {
+    "fields": [
+        {"key": "current_phase", "type": "text"},
+        {"key": "current_status", "type": "text"},
+        {"key": "current_dungeon", "type": "text"},
+        {"key": "reward_points", "type": "number"},
+        {"key": "gene_lock", "type": "text"},
+        {"key": "等級", "type": "text"},
+    ],
+    "lists": [
+        {"key": "inventory", "type": "map"},
+        {"key": "relationships", "type": "map"},
+        {"key": "abilities", "state_add_key": "abilities_add", "state_remove_key": "abilities_remove"},
+        {"key": "systems", "type": "map"},
+    ],
+    "direct_overwrite_keys": [
+        "current_phase",
+        "current_status",
+        "current_dungeon",
+        "gene_lock",
+        "等級",
+    ],
+}
+
+TEMPLATES = {
+    "dungeons": [
+        {
+            "id": "alien",
+            "name": "異形",
+            "difficulty": "B",
+            "mainline": {"nodes": [{"id": "node_1", "title": "發現異形"}]},
+            "areas": [{"id": "cargo_bay", "name": "貨艙", "initial_status": "discovered"}],
+            "progression_rules": {
+                "rank_progress": 0.5,
+                "gene_lock_gain": 10,
+                "gene_lock_stage_cap": "第一階 50%",
+                "base_reward": 1000,
+                "mainline_multiplier": 1.5,
+                "exploration_multiplier": 1.2,
+            },
+        },
+        {
+            "id": "naruto",
+            "name": "火影忍者",
+            "difficulty": "C",
+            "mainline": {"nodes": [{"id": "node_1", "title": "進入木葉"}]},
+            "areas": [{"id": "konoha_gate", "name": "木葉大門", "initial_status": "discovered"}],
+            "progression_rules": {
+                "rank_progress": 0.5,
+                "gene_lock_gain": 10,
+                "gene_lock_stage_cap": "第一階 50%",
+                "base_reward": 1000,
+                "mainline_multiplier": 1.5,
+                "exploration_multiplier": 1.2,
+            },
+        },
+    ]
+}
+
+
+def _write_json(path, data):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def _branch_dir(tmp_path):
+    return tmp_path / "data" / "stories" / STORY_ID / "branches" / BRANCH_ID
+
+
+def _story_dir(tmp_path):
+    return tmp_path / "data" / "stories" / STORY_ID
+
+
+def _design_dir(tmp_path):
+    return tmp_path / "story_design" / STORY_ID
+
+
+def _load_state(tmp_path):
+    path = _branch_dir(tmp_path) / "character_state.json"
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _load_progress(tmp_path):
+    path = _branch_dir(tmp_path) / "dungeon_progress.json"
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _base_state(**overrides):
+    state = {
+        "current_phase": "主神空間",
+        "current_status": "待命",
+        "current_dungeon": "",
+        "reward_points": 100,
+        "gene_lock": "未開啟",
+        "等級": "D",
+        "inventory": {},
+        "relationships": {},
+        "abilities": [],
+        "systems": {},
+    }
+    state.update(overrides)
+    return state
+
+
+def _active_progress(dungeon_id="alien", **overrides):
+    progress = {
+        "history": [],
+        "total_dungeons_completed": 0,
+        "current_dungeon": {
+            "dungeon_id": dungeon_id,
+            "entered_at": "2026-03-07T00:00:00+00:00",
+            "entered_at_world_day": 1,
+            "current_world_day": 1,
+            "mainline_progress": 50,
+            "exploration_progress": 30,
+            "completed_nodes": [],
+            "discovered_areas": ["cargo_bay"],
+            "explored_areas": {"cargo_bay": 30},
+            "rank_on_enter": "D",
+            "gene_lock_on_enter": "未開啟",
+            "reward_points_on_enter": 100,
+            "growth_budget": {
+                "max_rank_progress": 0.5,
+                "consumed_rank_progress": 0,
+                "max_gene_lock_gain": 10,
+                "consumed_gene_lock": 0,
+            },
+        },
+    }
+    progress["current_dungeon"].update(overrides)
+    return progress
+
+
+class _InlineThread:
+    def __init__(self, target=None, args=(), kwargs=None, daemon=None):
+        self._target = target
+        self._args = args
+        self._kwargs = kwargs or {}
+
+    def start(self):
+        if self._target:
+            self._target(*self._args, **self._kwargs)
+
+
+def _identity_gate(update, *_args, **_kwargs):
+    return update
+
+
+def _noop(*_args, **_kwargs):
+    return None
+
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def patch_paths(tmp_path, monkeypatch):
+    stories_dir = tmp_path / "data" / "stories"
+    design_dir = tmp_path / "story_design"
+    stories_dir.mkdir(parents=True)
+    design_dir.mkdir(parents=True)
+
+    monkeypatch.setattr(app_module, "STORIES_DIR", str(stories_dir))
+    monkeypatch.setattr(app_module, "STORY_DESIGN_DIR", str(design_dir))
+    monkeypatch.setattr(app_module, "BASE_DIR", str(tmp_path))
+    monkeypatch.setattr(state_db, "STORIES_DIR", str(stories_dir))
+    monkeypatch.setattr(event_db, "STORIES_DIR", str(stories_dir))
+    monkeypatch.setattr(world_timer, "BASE_DIR", str(tmp_path))
+    monkeypatch.setattr(
+        dungeon_system,
+        "_story_dir",
+        lambda story_id: str(stories_dir / story_id),
+    )
+    monkeypatch.setattr(
+        dungeon_system,
+        "_branch_dir",
+        lambda story_id, branch_id: str(stories_dir / story_id / "branches" / branch_id),
+    )
+    monkeypatch.setattr(state_cleanup, "get_recap_text", lambda *_args, **_kwargs: "")
+
+    _write_json(_design_dir(tmp_path) / "character_schema.json", SCHEMA)
+    _write_json(_story_dir(tmp_path) / "dungeons_template.json", TEMPLATES)
+    _write_json(_branch_dir(tmp_path) / "npcs.json", [])
+
+    return tmp_path
+
+
+def test_reconcile_entry_uses_pre_transition_baseline(tmp_path):
+    _write_json(_branch_dir(tmp_path) / "character_state.json", _base_state())
+
+    old_state = _base_state(reward_points=100, gene_lock="未開啟", 等級="D")
+    new_state = _base_state(
+        current_dungeon="火影忍者",
+        current_phase="副本中",
+        reward_points=240,
+        gene_lock="第一階開啟中（進度 18%）",
+        等級="C",
+    )
+
+    dungeon_system.reconcile_dungeon_entry(STORY_ID, BRANCH_ID, old_state, new_state)
+
+    progress = _load_progress(tmp_path)
+    current = progress["current_dungeon"]
+    assert current["dungeon_id"] == "naruto"
+    assert current["rank_on_enter"] == "D"
+    assert current["gene_lock_on_enter"] == "未開啟"
+    assert current["reward_points_on_enter"] == 100
+
+
+def test_reconcile_exit_archives_with_new_state_and_initializes_switch(tmp_path):
+    _write_json(_branch_dir(tmp_path) / "character_state.json", _base_state(current_dungeon="異形"))
+    _write_json(_branch_dir(tmp_path) / "dungeon_progress.json", _active_progress())
+
+    old_state = _base_state(current_dungeon="異形", reward_points=100, 等級="D")
+    new_state = _base_state(current_dungeon="火影忍者", reward_points=250, 等級="C")
+
+    dungeon_system.reconcile_dungeon_exit(STORY_ID, BRANCH_ID, old_state, new_state)
+
+    progress = _load_progress(tmp_path)
+    assert progress["current_dungeon"]["dungeon_id"] == "naruto"
+    assert progress["current_dungeon"]["reward_points_on_enter"] == 250
+    assert progress["history"][0]["dungeon_id"] == "alien"
+    assert progress["history"][0]["rank_after"] == "C"
+    assert progress["history"][0]["reward_points_earned"] == 150
+
+
+def test_apply_state_update_initializes_progress_before_validation(tmp_path, monkeypatch):
+    _write_json(_branch_dir(tmp_path) / "character_state.json", _base_state())
+    monkeypatch.setattr(app_module, "_run_state_gate", _identity_gate)
+    monkeypatch.setattr(app_module, "_normalize_state_async", _noop)
+
+    app_module._apply_state_update(
+        STORY_ID,
+        BRANCH_ID,
+        {
+            "current_dungeon": "火影忍者",
+            "current_phase": "副本中",
+            "gene_lock": "第一階開啟中（進度 18%）",
+        },
+    )
+
+    state = _load_state(tmp_path)
+    progress = _load_progress(tmp_path)
+    assert state["gene_lock"] == "第一階開啟中（進度 10%）"
+    assert progress["current_dungeon"]["dungeon_id"] == "naruto"
+    assert progress["current_dungeon"]["gene_lock_on_enter"] == "未開啟"
+
+
+def test_apply_state_update_archives_after_validation_with_capped_state(tmp_path, monkeypatch):
+    _write_json(
+        _branch_dir(tmp_path) / "character_state.json",
+        _base_state(current_dungeon="異形", current_phase="副本中"),
+    )
+    _write_json(_branch_dir(tmp_path) / "dungeon_progress.json", _active_progress())
+    monkeypatch.setattr(app_module, "_run_state_gate", _identity_gate)
+    monkeypatch.setattr(app_module, "_normalize_state_async", _noop)
+
+    app_module._apply_state_update(
+        STORY_ID,
+        BRANCH_ID,
+        {
+            "current_dungeon": "",
+            "current_phase": "主神空間",
+            "gene_lock": "第一階開啟中（進度 18%）",
+        },
+    )
+
+    state = _load_state(tmp_path)
+    progress = _load_progress(tmp_path)
+    assert state["gene_lock"] == "第一階開啟中（進度 10%）"
+    assert progress.get("current_dungeon") is None
+    assert progress["history"][0]["gene_lock_after"] == "第一階開啟中（進度 10%）"
+
+
+def test_normalize_reconciles_after_reapply(tmp_path, monkeypatch):
+    _write_json(_branch_dir(tmp_path) / "character_state.json", _base_state())
+    monkeypatch.setattr(app_module, "_run_state_gate", _identity_gate)
+    monkeypatch.setattr(app_module, "_trace_llm", _noop)
+    monkeypatch.setattr(app_module, "_log_llm_usage", _noop)
+    monkeypatch.setattr(app_module.threading, "Thread", _InlineThread)
+    monkeypatch.setattr(
+        llm_bridge,
+        "call_oneshot",
+        lambda _prompt: json.dumps(
+            {"current_dungeon": "火影忍者", "current_phase": "副本中"},
+            ensure_ascii=False,
+        ),
+    )
+
+    app_module._normalize_state_async(STORY_ID, BRANCH_ID, {"副本名": "火影忍者"}, {"current_dungeon"})
+
+    progress = _load_progress(tmp_path)
+    assert progress["current_dungeon"]["dungeon_id"] == "naruto"
+
+
+def test_cleanup_reconciles_after_cleanup_batch(tmp_path, monkeypatch):
+    _write_json(_branch_dir(tmp_path) / "character_state.json", _base_state())
+    monkeypatch.setattr(app_module, "_trace_llm", _noop)
+    monkeypatch.setattr(app_module, "_log_llm_usage", _noop)
+    monkeypatch.setattr(
+        llm_bridge,
+        "call_oneshot",
+        lambda _prompt: json.dumps(
+            {
+                "archive_npcs": [],
+                "merge_npcs": [],
+                "resolve_events": [],
+                "remove_inventory": [],
+                "remove_abilities": [],
+                "add_abilities": [],
+                "update_systems": [],
+                "clean_relationships": [],
+            },
+            ensure_ascii=False,
+        ),
+    )
+
+    def _fake_apply_cleanup(story_id, branch_id, _ops):
+        schema = app_module._load_character_schema(story_id)
+        app_module._apply_state_update_inner(
+            story_id,
+            branch_id,
+            {"current_dungeon": "火影忍者", "current_phase": "副本中"},
+            schema,
+        )
+        return {
+            "archived_npcs": 0,
+            "merged_npcs": 0,
+            "resolved_events": 0,
+            "removed_inventory": 0,
+            "removed_abilities": 0,
+            "added_abilities": 0,
+            "updated_systems": 0,
+            "clean_relationships": 0,
+        }
+
+    monkeypatch.setattr(state_cleanup, "_apply_cleanup_operations", _fake_apply_cleanup)
+
+    state_cleanup._run_cleanup_core(STORY_ID, BRANCH_ID)
+
+    progress = _load_progress(tmp_path)
+    assert progress["current_dungeon"]["dungeon_id"] == "naruto"


### PR DESCRIPTION
## Summary
- add dungeon state reconciliation for narrative-path `current_dungeon` transitions
- hook reconciliation into state update, normalize, and cleanup flows
- fix a separate `state.db` consistency bug by re-syncing `state.db` after `validate_dungeon_progression()` mutates `new_state` in-place
- document the new safety-net behavior and add regression coverage

## Testing
- `pytest -q tests/test_dungeon_reconciliation.py`
- `pytest -q tests/test_state_update.py tests/test_state_cleanup.py tests/test_extract_tags_async.py tests/test_state_review.py`
