### PR TITLE
Fix debug panel proposal rendering

### DIFF
--- a/doc/api_reference.md
+++ b/doc/api_reference.md
@@ -119,6 +119,7 @@
 - `apply` 會先寫完整 backup，再逐項執行 action，回傳每項成功/失敗。
 - `actions` / `directives` 各自都有上限（預設 20，可由 env 覆蓋）；`directives` 只會採用最後一個非空 instruction。
 - `directive` 會獨立寫入 `debug_directive.json`，不受 action 失敗影響。
+- `audit_summary` 僅供 Debug Panel UI 顯示，不會另外寫入主聊天訊息。
 - `undo` 只支援最近一次 apply（同 debug unit，且 branch 要匹配）；若 backup 的 `world_day` 損壞，會直接回 `400`，不會 fallback 到目前值。
 
 ## NPC / Events / Images

--- a/doc/game_mechanics.md
+++ b/doc/game_mechanics.md
@@ -249,10 +249,10 @@
 - `promote`：保留 directive（同步到 parent 路徑）
 - 其他分支操作（create/blank/merge/delete/cleanup）：不複製 directive
 
-### 9.5 審計訊息
+### 9.5 UI 回饋
 
-- 每次 apply/undo 都會在主聊天寫一則 `message_type=debug_audit`
-- `debug_audit` 可見但不進 GM prompt、不進 compaction
+- `apply/undo/clear` 的摘要只保留在 Debug Panel API response 與面板內 UI
+- 主聊天不再插入 `debug_audit` 訊息，避免污染一般對話流
 
 ---
 

--- a/doc/prompt_design.md
+++ b/doc/prompt_design.md
@@ -278,6 +278,12 @@
 
 - 修正提案：`<!--DEBUG_ACTION {...} DEBUG_ACTION-->`
   - `type` 支援：`state_patch` / `npc_upsert` / `npc_delete` / `world_day_set` / `dungeon_patch`
+  - frontend 會沿用後端的 normalization 思路處理 alias payload，歷史訊息重載時也適用
+  - 目前接受的 state 類 alias 包含：
+    - `{"type":"state_patch","update":{...}}`
+    - `{"update":{...}}`
+    - `{"action":"state_patch","patch":{...}}`
+    - `{"state_patch":{...}}`
 - 劇情指令：`<!--DEBUG_DIRECTIVE {"instruction":"..."} DEBUG_DIRECTIVE-->`
   - apply 後寫入 branch `debug_directive.json`
   - 下次主 GM 回合注入 `_build_augmented_message`

--- a/routes/debug_routes.py
+++ b/routes/debug_routes.py
@@ -236,16 +236,6 @@ def api_debug_apply():
     audit_summary = app_module._build_debug_apply_audit_summary(
         results, directive_result.get("applied", 0)
     )
-    try:
-        app_module._append_debug_audit_message(story_id, branch_id, audit_summary)
-    except Exception as exc:
-        log.warning(
-            "debug apply audit append failed: story=%s branch=%s error=%s",
-            story_id,
-            branch_id,
-            exc,
-        )
-
     return jsonify(
         {
             "ok": True,
@@ -316,15 +306,6 @@ def api_debug_undo():
     app_module._clear_last_apply_backup(story_id, debug_unit_id)
 
     audit_summary = "已回滾 Debug 修正（還原至套用前）"
-    try:
-        app_module._append_debug_audit_message(story_id, branch_id, audit_summary)
-    except Exception as exc:
-        log.warning(
-            "debug undo audit append failed: story=%s branch=%s error=%s",
-            story_id,
-            branch_id,
-            exc,
-        )
     return jsonify({"ok": True, "restored": True, "audit_summary": audit_summary})
 
 

--- a/static/app.js
+++ b/static/app.js
@@ -4762,6 +4762,217 @@ init();
 // Debug Panel Layout
 // ==========================================
 
+const _DEBUG_ACTION_TYPES = new Set([
+  "state_patch",
+  "npc_upsert",
+  "npc_delete",
+  "world_day_set",
+  "dungeon_patch",
+]);
+
+const _DEBUG_DUNGEON_KEYS = [
+  "progress_delta",
+  "mainline_progress_delta",
+  "completed_nodes",
+  "discovered_areas",
+  "explored_area_updates",
+];
+
+function _normalizeDebugActionPayload(payload) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return null;
+
+  const data = { ...payload };
+  if (data.action && typeof data.action === "object" && !Array.isArray(data.action)) {
+    const nested = _normalizeDebugActionPayload(data.action);
+    if (nested) return nested;
+  }
+
+  const actionType = String(
+    data.type ||
+    data.action_type ||
+    data.kind ||
+    (typeof data.action === "string" ? data.action : "") ||
+    ""
+  ).trim();
+
+  if (_DEBUG_ACTION_TYPES.has(actionType)) {
+    const normalized = { ...data, type: actionType };
+    const payloadObj = normalized.payload;
+    if (payloadObj && typeof payloadObj === "object" && !Array.isArray(payloadObj)) {
+      Object.entries(payloadObj).forEach(([key, value]) => {
+        if (!(key in normalized)) normalized[key] = value;
+      });
+    }
+
+    if (actionType === "state_patch") {
+      const stateObj = normalized.state_patch;
+      const patchObj = normalized.patch;
+      const patchDataObj = normalized.patch_data;
+      if (!normalized.update || typeof normalized.update !== "object" || Array.isArray(normalized.update)) {
+        if (stateObj && typeof stateObj === "object" && !Array.isArray(stateObj)) {
+          normalized.update = stateObj;
+        } else if (patchObj && typeof patchObj === "object" && !Array.isArray(patchObj)) {
+          normalized.update = patchObj;
+        } else if (patchDataObj && typeof patchDataObj === "object" && !Array.isArray(patchDataObj)) {
+          normalized.update = patchDataObj;
+        } else {
+          const extras = {};
+          Object.entries(normalized).forEach(([key, value]) => {
+            if (![
+              "type",
+              "action_type",
+              "kind",
+              "action",
+              "payload",
+              "state_patch",
+              "patch",
+              "patch_data",
+            ].includes(key)) {
+              extras[key] = value;
+            }
+          });
+          if (Object.keys(extras).length > 0) normalized.update = extras;
+        }
+      }
+    } else if (actionType === "npc_upsert") {
+      const npcObj = normalized.npc_upsert;
+      if ((!normalized.npc || typeof normalized.npc !== "object" || Array.isArray(normalized.npc))
+        && npcObj && typeof npcObj === "object" && !Array.isArray(npcObj)) {
+        normalized.npc = npcObj;
+      }
+    } else if (actionType === "npc_delete") {
+      if (!String(normalized.npc_id || "").trim()) {
+        const npcDeleteVal = normalized.npc_delete;
+        if (typeof npcDeleteVal === "string" && npcDeleteVal.trim()) {
+          normalized.npc_id = npcDeleteVal.trim();
+        }
+      }
+    } else if (actionType === "world_day_set") {
+      if (!("world_day" in normalized) && ("value" in normalized)) {
+        normalized.world_day = normalized.value;
+      }
+    } else if (actionType === "dungeon_patch") {
+      const dungeonObj = normalized.dungeon_patch;
+      if (dungeonObj && typeof dungeonObj === "object" && !Array.isArray(dungeonObj)) {
+        Object.entries(dungeonObj).forEach(([key, value]) => {
+          if (!(key in normalized)) normalized[key] = value;
+        });
+      }
+    }
+
+    return normalized;
+  }
+
+  if (data.update && typeof data.update === "object" && !Array.isArray(data.update)) {
+    return { type: "state_patch", update: data.update };
+  }
+  if (data.patch && typeof data.patch === "object" && !Array.isArray(data.patch)) {
+    return { type: "state_patch", update: data.patch };
+  }
+  if (data.patch_data && typeof data.patch_data === "object" && !Array.isArray(data.patch_data)) {
+    return { type: "state_patch", update: data.patch_data };
+  }
+  if ("world_day" in data) {
+    return { type: "world_day_set", world_day: data.world_day };
+  }
+  if (data.npc && typeof data.npc === "object" && !Array.isArray(data.npc)) {
+    return { type: "npc_upsert", npc: data.npc };
+  }
+
+  const npcId = String(data.npc_id || "").trim();
+  if (npcId) {
+    return { type: "npc_delete", npc_id: npcId };
+  }
+
+  if (_DEBUG_DUNGEON_KEYS.some((key) => key in data)) {
+    const out = { type: "dungeon_patch" };
+    _DEBUG_DUNGEON_KEYS.forEach((key) => {
+      if (key in data) out[key] = data[key];
+    });
+    return out;
+  }
+
+  for (const key of _DEBUG_ACTION_TYPES) {
+    if (!(key in data)) continue;
+    const value = data[key];
+
+    if (key === "state_patch") {
+      if (value && typeof value === "object" && !Array.isArray(value)) {
+        if (value.update && typeof value.update === "object" && !Array.isArray(value.update)) {
+          return { type: "state_patch", update: value.update };
+        }
+        return { type: "state_patch", update: value };
+      }
+      return null;
+    }
+
+    if (key === "npc_upsert") {
+      if (value && typeof value === "object" && !Array.isArray(value)) {
+        if (value.npc && typeof value.npc === "object" && !Array.isArray(value.npc)) {
+          return { type: "npc_upsert", npc: value.npc };
+        }
+        return { type: "npc_upsert", npc: value };
+      }
+      return null;
+    }
+
+    if (key === "npc_delete") {
+      if (value && typeof value === "object" && !Array.isArray(value)) {
+        const nestedId = String(value.npc_id || "").trim();
+        if (nestedId) return { type: "npc_delete", npc_id: nestedId };
+        return null;
+      }
+      if (typeof value === "string" && value.trim()) {
+        return { type: "npc_delete", npc_id: value.trim() };
+      }
+      return null;
+    }
+
+    if (key === "world_day_set") {
+      if (value && typeof value === "object" && !Array.isArray(value) && ("world_day" in value)) {
+        return { type: "world_day_set", world_day: value.world_day };
+      }
+      return { type: "world_day_set", world_day: value };
+    }
+
+    if (key === "dungeon_patch") {
+      if (value && typeof value === "object" && !Array.isArray(value)) {
+        const out = { type: "dungeon_patch" };
+        _DEBUG_DUNGEON_KEYS.forEach((dungeonKey) => {
+          if (dungeonKey in value) out[dungeonKey] = value[dungeonKey];
+        });
+        return out;
+      }
+      return null;
+    }
+  }
+
+  return null;
+}
+
+function _splitDebugProposals(proposals) {
+  const out = [];
+
+  (proposals || []).forEach((proposal) => {
+    const normalized = _normalizeDebugActionPayload(proposal);
+    if (!normalized) return;
+
+    if (normalized.type === "state_patch") {
+      const updateObj = normalized.update || normalized.patch;
+      if (updateObj && typeof updateObj === "object" && !Array.isArray(updateObj)) {
+        Object.entries(updateObj).forEach(([key, value]) => {
+          out.push({ type: "state_patch", update: { [key]: value } });
+        });
+      }
+      return;
+    }
+
+    out.push(normalized);
+  });
+
+  return out;
+}
+
 function _parseDebugContent(text) {
   if (!text) return { cleanText: "", proposals: [], directives: [] };
   const proposals = [];
@@ -4770,18 +4981,7 @@ function _parseDebugContent(text) {
   // Extract actions
   let cleanText = text.replace(/<!--DEBUG_ACTION\s+([\s\S]*?)\s+DEBUG_ACTION-->/g, (match, jsonStr) => {
     try {
-      const p = JSON.parse(jsonStr);
-      // Support both 'update' and 'patch' keys for state_patch
-      if (p.type === "state_patch") {
-        const updateObj = p.update || p.patch;
-        if (updateObj && typeof updateObj === "object") {
-          for (const [key, value] of Object.entries(updateObj)) {
-            proposals.push({ type: "state_patch", update: { [key]: value } });
-          }
-        }
-      } else {
-        proposals.push(p);
-      }
+      proposals.push(..._splitDebugProposals([JSON.parse(jsonStr)]));
     } catch (e) {
       console.warn("Failed to parse debug action:", e);
     }
@@ -4848,7 +5048,7 @@ function _renderInlineProposalCards(container, proposals, directives) {
   proposals.forEach((p, i) => {
     let badgeClass = "edit";
     let badgeText = "狀態";
-    let topic = p.type;
+    let topic = p.type || "未分類";
     let contentHtml = "";
 
     if (p.type === "state_patch") {
@@ -4874,7 +5074,9 @@ function _renderInlineProposalCards(container, proposals, directives) {
     } else if (p.type === "dungeon_patch") {
       badgeClass = "edit"; badgeText = "副本";
       topic = "推進進度";
-      contentHtml = `變更為: ${JSON.stringify(p.update)}`;
+      contentHtml = `變更為: ${JSON.stringify(p)}`;
+    } else {
+      contentHtml = JSON.stringify(p);
     }
 
     const card = document.createElement("div");
@@ -5060,20 +5262,7 @@ async function sendDebugChat() {
           target.innerHTML = markdownToHtml(stripDebugTags(finalText));
         }
 
-        const rawProposals = data.proposals || [];
-        const splitProposals = [];
-        rawProposals.forEach(p => {
-          if (p.type === "state_patch") {
-            const updateObj = p.update || p.patch;
-            if (updateObj && typeof updateObj === "object") {
-              for (const [key, value] of Object.entries(updateObj)) {
-                splitProposals.push({ type: "state_patch", update: { [key]: value } });
-              }
-            }
-          } else {
-            splitProposals.push(p);
-          }
-        });
+        const splitProposals = _splitDebugProposals(data.proposals || []);
 
         _debugPendingProposals = splitProposals;
         _debugPendingDirectives = data.directives || [];

--- a/tests/test_debug_api.py
+++ b/tests/test_debug_api.py
@@ -242,7 +242,7 @@ def test_debug_apply_partial_success_and_audit(client, setup_story):
     assert directive_path.exists()
 
     messages = json.loads((setup_story / "branches" / "main" / "messages.json").read_text(encoding="utf-8"))
-    assert any(m.get("message_type") == "debug_audit" for m in messages)
+    assert not any(m.get("message_type") == "debug_audit" for m in messages)
 
 
 def test_debug_apply_rejects_too_many_directives(client, setup_story):
@@ -329,9 +329,7 @@ def test_debug_undo_restores_snapshot_and_clears_directive(client, setup_story):
     assert not directive_path.exists()
 
     messages = json.loads((setup_story / "branches" / "main" / "messages.json").read_text(encoding="utf-8"))
-    audits = [m for m in messages if m.get("message_type") == "debug_audit"]
-    assert len(audits) == 2
-    assert "已回滾 Debug 修正" in audits[-1]["content"]
+    assert not any(m.get("message_type") == "debug_audit" for m in messages)
 
 
 def test_debug_undo_rejects_invalid_backup_world_day_without_partial_restore(client, setup_story):

--- a/tests/test_frontend_debug_panel.py
+++ b/tests/test_frontend_debug_panel.py
@@ -1,0 +1,81 @@
+"""Regression tests for Debug Panel frontend parsing helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import shutil
+import subprocess
+
+import pytest
+
+
+APP_JS_PATH = Path(__file__).resolve().parents[1] / "static" / "app.js"
+
+
+def _run_debug_panel_expr(expr: str):
+    if shutil.which("node") is None:
+        pytest.skip("node is required for frontend parser regression tests")
+
+    script = f"""
+const fs = require("fs");
+const vm = require("vm");
+
+const src = fs.readFileSync({json.dumps(str(APP_JS_PATH))}, "utf8");
+const start = src.indexOf("const _DEBUG_ACTION_TYPES = new Set([");
+const end = src.indexOf("function _renderDebugChatMessages");
+if (start < 0 || end < 0 || end <= start) {{
+  throw new Error("debug panel parser snippet markers not found");
+}}
+
+const snippet = src.slice(start, end);
+const ctx = {{ console }};
+vm.createContext(ctx);
+vm.runInContext(snippet, ctx);
+
+const result = {expr};
+process.stdout.write(JSON.stringify(result));
+"""
+
+    proc = subprocess.run(
+        ["node", "-e", script],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=APP_JS_PATH.parents[1],
+    )
+    assert proc.returncode == 0, proc.stderr or proc.stdout
+    return json.loads(proc.stdout)
+
+
+def test_parse_debug_content_normalizes_nested_state_patch_alias():
+    text = (
+        "先做檢查。\n"
+        "<!--DEBUG_ACTION "
+        '{"state_patch":{"inventory":{"阿豪":"深度休眠修復中"},"current_status":"閉關整理中"}}'
+        " DEBUG_ACTION-->\n"
+        "<!--DEBUG_DIRECTIVE "
+        '{"instruction":"下一回合沿用新的技能描述"}'
+        " DEBUG_DIRECTIVE-->"
+    )
+
+    parsed = _run_debug_panel_expr(f"ctx._parseDebugContent({json.dumps(text)})")
+
+    assert parsed["cleanText"] == "先做檢查。"
+    assert parsed["proposals"] == [
+        {"type": "state_patch", "update": {"inventory": {"阿豪": "深度休眠修復中"}}},
+        {"type": "state_patch", "update": {"current_status": "閉關整理中"}},
+    ]
+    assert parsed["directives"] == [{"instruction": "下一回合沿用新的技能描述"}]
+
+
+def test_split_debug_proposals_normalizes_patch_alias():
+    proposals = [
+        {"action": "state_patch", "patch": {"reward_points_delta": 7}},
+    ]
+
+    parsed = _run_debug_panel_expr(f"ctx._splitDebugProposals({json.dumps(proposals, ensure_ascii=False)})")
+
+    assert parsed == [
+        {"type": "state_patch", "update": {"reward_points_delta": 7}},
+    ]


### PR DESCRIPTION
## Summary
- normalize Debug Panel action payloads in the frontend so historical reloads render alias forms like {"state_patch": {...}} correctly
- stop writing Debug apply/undo audit summaries into the main chat timeline
- add frontend parser regression coverage and update Debug Panel docs

## Testing
- pytest tests/test_frontend_debug_panel.py tests/test_debug_api.py -q
- pytest tests/test_context_injection.py tests/test_compaction.py -q