### PR TITLE
Reduce mobile load cost by compressing responses and tail-loading timelines

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,6 +13,7 @@ else:
     __version__ = "0.0.0"
 
 from flask import Flask
+from flask_compress import Compress
 
 # ---------------------------------------------------------------------------
 # Logging — console + rotating file
@@ -51,6 +52,8 @@ from story_core.app_helpers import *  # noqa: F401,F403
 # Flask App
 # ---------------------------------------------------------------------------
 app = Flask(__name__)
+app.config["COMPRESS_STREAMS"] = False
+Compress(app)
 app.register_blueprint(lore_bp)
 app.register_blueprint(branch_bp)
 app.register_blueprint(debug_bp)

--- a/doc/api_reference.md
+++ b/doc/api_reference.md
@@ -42,7 +42,7 @@
 
 | Method | Path | 說明 | 主要參數 |
 |---|---|---|---|
-| GET | `/api/messages` | 取得分支完整 timeline（含 fork/sibling/world_day） | `branch_id`, `offset`, `limit`, `after_index`, `tail` |
+| GET | `/api/messages` | 取得分支完整 timeline（含 fork/sibling/world_day；不含 per-message snapshot 欄位） | `branch_id`, `offset`, `limit`, `after_index`, `tail` |
 | POST | `/api/send` | 送出玩家訊息，取得完整 GM 回覆 | body: `message`, `branch_id` |
 | POST | `/api/send/stream` | `send` 的 SSE 版本 | body: `message`, `branch_id` |
 | GET | `/api/status` | 取得角色狀態（含 world_day、cheat 狀態） | `branch_id` |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 flask
+flask-compress
 markdown
 numpy
 fastembed

--- a/routes/core_routes.py
+++ b/routes/core_routes.py
@@ -12,6 +12,13 @@ from flask import Blueprint, Response, jsonify, render_template, request, stream
 
 log = logging.getLogger("rpg")
 core_bp = Blueprint("core", __name__)
+_MESSAGE_RESPONSE_STRIP_KEYS = {
+    "state_snapshot",
+    "npcs_snapshot",
+    "world_day_snapshot",
+    "dungeon_progress_snapshot",
+    "snapshot_async_synced_at",
+}
 
 
 def _app():
@@ -23,6 +30,12 @@ def _app():
 def _sse_event(data: dict) -> str:
     """Format a dict as an SSE data line."""
     return f"data: {json.dumps(data, ensure_ascii=False)}\n\n"
+
+
+def _serialize_message_for_response(message: dict) -> dict:
+    return {
+        key: value for key, value in message.items() if key not in _MESSAGE_RESPONSE_STRIP_KEYS
+    }
 
 
 @core_bp.route("/")
@@ -122,6 +135,7 @@ def api_messages():
         page = [message for message in timeline if message.get("index", 0) > after_index]
     else:
         page = timeline[offset : offset + limit]
+    page = [_serialize_message_for_response(message) for message in page]
     fork_points = app_module._get_fork_points(story_id, branch_id)
     sibling_groups = app_module._get_sibling_groups(story_id, branch_id)
 

--- a/static/app.js
+++ b/static/app.js
@@ -428,6 +428,9 @@ let _incompletePollBranchId = null;
 let _debugSession = null;
 let _debugPendingProposals = [];
 let _debugPendingDirectives = [];
+const DEFAULT_BRANCH_TAIL = 50;
+const AUTO_BRANCH_TAIL = 100;
+const RECENT_IMAGE_POLL_COUNT = 10;
 
 function isAutoBranch(branchId) {
   return branchId && branchId.startsWith("auto_");
@@ -461,6 +464,68 @@ function updateWorldDayDisplay(worldDay) {
   else period = "夜晚";
 
   el.textContent = `✦ 世界第 ${day} 天 · ${period}`;
+}
+
+function getDefaultMessageTail(branchId) {
+  return isAutoBranch(branchId) ? AUTO_BRANCH_TAIL : DEFAULT_BRANCH_TAIL;
+}
+
+function _topVisibleMessageAnchor() {
+  const container = document.getElementById("messages");
+  const nodes = Array.from($messages.querySelectorAll(".message[data-index]"));
+  if (!container || nodes.length === 0) return null;
+
+  for (const node of nodes) {
+    if (node.offsetTop + node.offsetHeight > container.scrollTop + 1) {
+      return {
+        index: Number(node.dataset.index),
+        offset: node.offsetTop - container.scrollTop,
+      };
+    }
+  }
+
+  const last = nodes[nodes.length - 1];
+  return {
+    index: Number(last.dataset.index),
+    offset: last.offsetTop - container.scrollTop,
+  };
+}
+
+function _restoreMessageAnchor(anchor) {
+  if (!anchor) return false;
+  const container = document.getElementById("messages");
+  const target = $messages.querySelector(`.message[data-index="${anchor.index}"]`);
+  if (!container || !target) return false;
+  container.scrollTop = Math.max(0, target.offsetTop - anchor.offset);
+  return true;
+}
+
+async function loadAllMessagesPreservingViewport(branchId) {
+  const anchor = _topVisibleMessageAnchor();
+  await loadMessages(branchId, { loadAll: true });
+  _restoreMessageAnchor(anchor);
+}
+
+function updateLoadEarlierButton(branchId) {
+  if (!$loadBtn) return;
+  if (allMessages.length < totalMessages) {
+    $loadBtn.style.display = "";
+    $loadBtn.disabled = false;
+    $loadBtn.onclick = async () => {
+      if (currentBranchId !== branchId) return;
+      $loadBtn.disabled = true;
+      try {
+        await loadAllMessagesPreservingViewport(branchId);
+      } finally {
+        $loadBtn.disabled = false;
+      }
+    };
+    return;
+  }
+
+  $loadBtn.style.display = "none";
+  $loadBtn.disabled = false;
+  $loadBtn.onclick = null;
 }
 
 function startLivePolling(branchId) {
@@ -704,11 +769,7 @@ async function init() {
 
     // 4. Load messages for active branch
     updateInitStatus("載入對話紀錄…");
-    if (isAutoBranch(currentBranchId)) {
-      await loadMessages(currentBranchId, { tail: 100 });
-    } else {
-      await loadMessages(currentBranchId);
-    }
+    await loadMessages(currentBranchId);
 
     // 5. Load character status
     updateInitStatus("載入角色狀態…");
@@ -733,23 +794,17 @@ async function init() {
       // Clean URL without reloading
       window.history.replaceState({}, "", "/");
     } else if (!isNaN(paramMsg) && paramMsg >= 0) {
-      const target = document.querySelector(`.message[data-index="${paramMsg}"]`);
+      let target = document.querySelector(`.message[data-index="${paramMsg}"]`);
+      if (!target && allMessages.length < totalMessages) {
+        await loadMessages(currentBranchId, { loadAll: true });
+        target = document.querySelector(`.message[data-index="${paramMsg}"]`);
+      }
       if (target) target.scrollIntoView({ block: "center" });
       window.history.replaceState({}, "", "/");
     }
 
     removeInitOverlay();
     if (!paramBranch && isNaN(paramMsg)) scrollToBottom();
-
-    // Show "load earlier" button for auto branches with truncated messages
-    if (isAutoBranch(currentBranchId) && allMessages.length < totalMessages) {
-      $loadBtn.style.display = "";
-      $loadBtn.onclick = async () => {
-        $loadBtn.style.display = "none";
-        await loadMessages(currentBranchId);
-        scrollToBottom();
-      };
-    }
 
     // Init addon panel
     initAddonPanel();
@@ -1597,10 +1652,12 @@ async function switchToBranch(branchId, { scrollToIndex, scrollBlock, preserveSc
       $messages.style.minHeight = $messages.scrollHeight + "px";
     }
 
-    if (isAutoBranch(branchId)) {
-      await loadMessages(branchId, { tail: 100 });
-    } else {
-      await loadMessages(branchId);
+    await loadMessages(branchId);
+    if (scrollToIndex != null) {
+      const target = $messages.querySelector(`.message[data-index="${scrollToIndex}"]`);
+      if (!target && allMessages.length < totalMessages) {
+        await loadMessages(branchId, { loadAll: true });
+      }
     }
     const status = await API.status(branchId);
     renderCharacterStatus(status);
@@ -1612,18 +1669,6 @@ async function switchToBranch(branchId, { scrollToIndex, scrollBlock, preserveSc
     loadDiceCheatStatus();
     loadPistolModeStatus();
     loadImageGenAddonState();
-
-    // Show/hide "load earlier" button for auto branches with truncated messages
-    if (isAutoBranch(branchId) && allMessages.length < totalMessages) {
-      $loadBtn.style.display = "";
-      $loadBtn.onclick = async () => {
-        $loadBtn.style.display = "none";
-        await loadMessages(branchId);
-        scrollToBottom();
-      };
-    } else {
-      $loadBtn.style.display = "none";
-    }
 
     if (isAutoBranch(branchId)) {
       startLivePolling(branchId);
@@ -1671,9 +1716,10 @@ async function switchToBranch(branchId, { scrollToIndex, scrollBlock, preserveSc
   scrollToBottom();
 }
 
-async function loadMessages(branchId, { tail } = {}) {
-  const msgResult = tail
-    ? await API.messages(branchId, 0, 99999, null, tail)
+async function loadMessages(branchId, { tail, loadAll } = {}) {
+  const effectiveTail = loadAll ? null : (tail ?? getDefaultMessageTail(branchId));
+  const msgResult = effectiveTail != null
+    ? await API.messages(branchId, 0, 99999, null, effectiveTail)
     : await API.messages(branchId, 0, 99999);
   totalMessages = msgResult.total;
   allMessages = msgResult.messages;
@@ -1681,6 +1727,7 @@ async function loadMessages(branchId, { tail } = {}) {
   forkPoints = msgResult.fork_points || {};
   siblingGroups = msgResult.sibling_groups || {};
   renderMessages(allMessages);
+  updateLoadEarlierButton(branchId);
   updateWorldDayDisplay(msgResult.world_day);
 
   // Handle incomplete branch (edit/regen interrupted before GM response)
@@ -1852,7 +1899,7 @@ async function submitEdit(msg, newText) {
         if (errMsg !== "AbortError") {
           if (errMsg === "no_change") {
             // Content unchanged — restore DOM to pre-edit state
-            loadMessages();
+            loadMessages(currentBranchId);
             showToast("內容未變更");
           } else {
             loadBranches().then(() => renderBranchList());
@@ -2046,6 +2093,8 @@ function renderMessages(messages) {
   const currentBranch = branches[currentBranchId];
   const branchPointIndex = currentBranch ? currentBranch.branch_point_index : null;
   let branchDividerInserted = false;
+  const recentStart = Math.max(0, messages.length - RECENT_IMAGE_POLL_COUNT);
+  const recentThreshold = messages[recentStart]?.index ?? -1;
 
   for (const msg of messages) {
     if (!dividerInserted && currentBranchId === "main" && msg.index >= originalCount && originalCount > 0) {
@@ -2159,7 +2208,7 @@ function renderMessages(messages) {
 
     // Render image if present
     if (msg.image && currentStoryId) {
-      renderMessageImage(el, msg, currentStoryId);
+      renderMessageImage(el, msg, currentStoryId, { recent: msg.index >= recentThreshold });
     }
 
     el.appendChild(actionsContainer);
@@ -4137,7 +4186,7 @@ function startImagePolling(storyId, filename, imgEl, {
   }
 }
 
-function renderMessageImage(parentEl, msg, storyId, { fresh = false } = {}) {
+function renderMessageImage(parentEl, msg, storyId, { fresh = false, recent = true } = {}) {
   if (!msg.image) return;
   const wrapper = document.createElement("div");
   wrapper.className = "msg-image-wrapper";
@@ -4172,17 +4221,19 @@ function renderMessageImage(parentEl, msg, storyId, { fresh = false } = {}) {
         onReady: showReadyImage,
       });
     } else {
-      // Page load — check once, then briefly retry in case the file finished moments later.
+      // Historical page load — old pending images do a single probe only.
       API.imageStatus(msg.image.filename).then(res => {
         handleImageWarning(msg.image.filename, res, storyId);
         if (res.ready) {
           showReadyImage();
-        } else {
+        } else if (recent) {
           startImagePolling(storyId, msg.image.filename, img, {
             maxWait: 15000,
             removeWrapperOnTimeout: true,
             onReady: showReadyImage,
           });
+        } else {
+          wrapper.remove();
         }
       }).catch(() => {
         wrapper.remove();
@@ -4204,13 +4255,16 @@ async function sendMessage() {
   $input.value = "";
   $input.style.height = "auto";
 
-  const playerMsg = { role: "user", content: text, index: allMessages.length, inherited: false, owner_branch_id: currentBranchId };
+  const lastIdx = allMessages.length > 0
+    ? Number(allMessages[allMessages.length - 1].index ?? -1)
+    : -1;
+  const playerMsg = { role: "user", content: text, index: lastIdx + 1, inherited: false, owner_branch_id: currentBranchId };
   allMessages.push(playerMsg);
   const playerEl = appendMessage(playerMsg);
   scrollToBottom();
 
   // Create GM bubble immediately for streaming
-  const gmMsgIndex = allMessages.length;
+  const gmMsgIndex = lastIdx + 2;
   const gmEl = document.createElement("div");
   gmEl.className = "message gm";
   gmEl.dataset.index = gmMsgIndex;

--- a/static/app.js
+++ b/static/app.js
@@ -471,15 +471,15 @@ function getDefaultMessageTail(branchId) {
 }
 
 function _topVisibleMessageAnchor() {
-  const container = document.getElementById("messages");
+  const scrollContainer = document.getElementById("messages");
   const nodes = Array.from($messages.querySelectorAll(".message[data-index]"));
-  if (!container || nodes.length === 0) return null;
+  if (!scrollContainer || nodes.length === 0) return null;
 
   for (const node of nodes) {
-    if (node.offsetTop + node.offsetHeight > container.scrollTop + 1) {
+    if (node.offsetTop + node.offsetHeight > scrollContainer.scrollTop + 1) {
       return {
         index: Number(node.dataset.index),
-        offset: node.offsetTop - container.scrollTop,
+        offset: node.offsetTop - scrollContainer.scrollTop,
       };
     }
   }
@@ -487,16 +487,16 @@ function _topVisibleMessageAnchor() {
   const last = nodes[nodes.length - 1];
   return {
     index: Number(last.dataset.index),
-    offset: last.offsetTop - container.scrollTop,
+    offset: last.offsetTop - scrollContainer.scrollTop,
   };
 }
 
 function _restoreMessageAnchor(anchor) {
   if (!anchor) return false;
-  const container = document.getElementById("messages");
+  const scrollContainer = document.getElementById("messages");
   const target = $messages.querySelector(`.message[data-index="${anchor.index}"]`);
-  if (!container || !target) return false;
-  container.scrollTop = Math.max(0, target.offsetTop - anchor.offset);
+  if (!scrollContainer || !target) return false;
+  scrollContainer.scrollTop = Math.max(0, target.offsetTop - anchor.offset);
   return true;
 }
 
@@ -517,7 +517,7 @@ function updateLoadEarlierButton(branchId) {
       try {
         await loadAllMessagesPreservingViewport(branchId);
       } finally {
-        $loadBtn.disabled = false;
+        if (currentBranchId === branchId) $loadBtn.disabled = false;
       }
     };
     return;
@@ -612,7 +612,7 @@ function startIncompletePolling(branchId) {
   const poll = async () => {
     if (_incompletePollBranchId !== branchId) return;
     try {
-      const data = await API.messages(branchId, 0, 99999);
+      const data = await API.messages(branchId, 0, 99999, null, 1);
       if (_incompletePollBranchId !== branchId) return;
 
       if (!data.incomplete) {

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -938,6 +938,40 @@ class TestMessagesAPI:
         assert "messages" in data
         assert len(data["messages"]) == 4
 
+    def test_get_messages_strips_snapshot_fields(self, client, setup_story):
+        branch_dir = setup_story / "branches" / "main"
+        (branch_dir / "messages.json").write_text(
+            json.dumps(
+                [
+                    {
+                        "index": 4,
+                        "role": "gm",
+                        "content": "快照測試",
+                        "state_snapshot": {"reward_points": 999},
+                        "npcs_snapshot": [{"name": "測試 NPC"}],
+                        "world_day_snapshot": 3.5,
+                        "dungeon_progress_snapshot": {"in_dungeon": True},
+                        "snapshot_async_synced_at": "2026-01-01T00:00:00Z",
+                    }
+                ],
+                ensure_ascii=False,
+            ),
+            encoding="utf-8",
+        )
+
+        resp = client.get("/api/messages")
+        assert resp.status_code == 200
+        messages = resp.get_json()["messages"]
+        assert messages[-1]["content"] == "快照測試"
+        for key in (
+            "state_snapshot",
+            "npcs_snapshot",
+            "world_day_snapshot",
+            "dungeon_progress_snapshot",
+            "snapshot_async_synced_at",
+        ):
+            assert key not in messages[-1]
+
     def test_get_messages_with_after_index(self, client, setup_story):
         resp = client.get("/api/messages?after_index=2")
         assert resp.status_code == 200

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -979,6 +979,13 @@ class TestMessagesAPI:
         messages = data["messages"]
         assert all(m["index"] > 2 for m in messages)
 
+    def test_get_messages_with_tail(self, client, setup_story):
+        resp = client.get("/api/messages?tail=2")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["total"] == 4
+        assert [m["index"] for m in data["messages"]] == [2, 3]
+
     def test_no_incomplete_banner_for_user_only_mid_route_with_child(self, client, setup_story):
         tree_path = setup_story / "timeline_tree.json"
         tree = json.loads(tree_path.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary

This PR reduces first-load cost on mobile by shrinking `/api/messages`, enabling HTTP compression for normal responses, and avoiding unnecessary image polling/render work on old history.

## What Changed

- enabled `flask-compress` for normal responses and explicitly disabled stream compression so SSE endpoints keep chunking normally
- stripped per-message snapshot fields from `/api/messages` responses
- changed frontend message loading to default to the last 50 messages for regular branches and 100 for auto branches
- generalized the `載入更早的訊息` button for any truncated branch and preserved viewport position when expanding history
- added fallback reload-to-full-history when a requested `scrollToIndex` is outside the tail window
- fixed optimistic message indices after tail-loading so temporary `#index` values still match timeline order
- limited stale image polling on page load to recent messages only; older not-ready images do a single probe and then drop

## Impact

Measured against the current real dataset used locally:

- `/api/messages` full payload: about `1.27 MB raw`, `302 KB gzip` after snapshot trimming
- `/api/messages?tail=50`: about `291 KB raw`, `71 KB gzip`

## Validation

- `node --check static/app.js`
- `python3 -m pytest tests/test_api_routes.py`

Result: `82 passed`
