### PR TITLE
Add layered story memory anchors and sticky events

### DIFF
--- a/doc/development.md
+++ b/doc/development.md
@@ -74,6 +74,7 @@ pytest tests/test_debug_api.py
 | `scripts/backfill/backfill_snapshots.py` | 回填歷史 GM 訊息 snapshot |
 | `scripts/backfill/backfill_branch_titles.py` | 回填分支標題 |
 | `scripts/backfill/backfill_npc_lifecycle.py` | 回填 NPC lifecycle + R1 去重 + 重建 `state.db` |
+| `scripts/backfill/backfill_story_memory.py` | 回填 `story_anchors` 與 sticky events（建議先 `--dry-run`） |
 | `scripts/migrations/migrate_current_dungeon.py` | 回填 `current_dungeon` |
 | `scripts/state/cleanup_character_state.py` | 清理/修復 state 汙染 |
 | `scripts/state/clean_state.py` | 移除 legacy 垃圾欄位 |
@@ -82,6 +83,15 @@ pytest tests/test_debug_api.py
 
 多數腳本支援 `--dry-run`；先 dry-run 再 apply。
 腳本分類可參考 `scripts/README.md`。
+
+`backfill_story_memory.py` 範例：
+
+```bash
+python3 scripts/backfill/backfill_story_memory.py \
+  --story-id story_original \
+  --branch-id branch_69569153 \
+  --dry-run
+```
 
 ## 5) 日常開發建議流程
 

--- a/doc/game_mechanics.md
+++ b/doc/game_mechanics.md
@@ -137,12 +137,30 @@
 ### 7.2 Event
 
 - 存於 `events.db`
-- 注入只取 active 事件（`planted/triggered`）
+- query-based 注入只取 active 事件（`planted/triggered`），以 `[相關事件追蹤]` 呈現
+- `sticky_priority > 0` 的事件會額外以 `[長期關鍵事件]` 常駐注入，依 `sticky_priority DESC, id DESC` 取最多 4 條
+- sticky events 可包含 `resolved` 狀態；用途是保留跨弧線 plot pressure，而不是即時場景相關性
 - async extraction 會做標題去重與狀態升級
+- async extraction 的 `event_ops` / legacy `events` 可附 `sticky: true`，寫入為 `sticky_priority=1`
 - fork 分支時會繼承 parent 在 `branch_point_index` 之前的事件，並保留 `message_index IS NULL` 的 legacy 條目
+- fork / merge 會保留 `sticky_priority`
 - 刪除分支（hard delete / `was_main` soft-delete）與啟動時 incomplete branch cleanup 會同步清除該分支事件，避免 orphan records
 
-### 7.3 NPC tier（戰力細分）
+### 7.3 Story anchors（身份層長期記憶）
+
+- 存於各分支 `character_state.json` 的 `story_anchors`
+- 上限 10 條，讀取時會 self-heal / normalize / 去重
+- 注入位置是 system prompt 的 `critical_facts -> ### 長期記憶`
+- 用途是 identity layer 的持久事實：
+  - 長期主線
+  - 核心隊伍關係
+  - 永久代價 / 不可逆變化
+  - 已成為角色身份一部分的長期宿敵 / 契約 / 追索壓力
+- `story_anchors` 和 sticky events 分工不同：
+  - anchors = 身份層事實
+  - sticky events = 劇情壓力
+
+### 7.4 NPC tier（戰力細分）
 
 - NPC 可帶 `tier` 欄位，允許 15 個值：`D-/D/D+/C-/C/C+/B-/B/B+/A-/A/A+/S-/S/S+`。
 - async extraction prompt 會提取 `tier`；若既有 NPC 本回合無法判定，應省略欄位而非覆蓋成 `null`。
@@ -152,7 +170,7 @@
   - `critical_facts` 的關係矩陣（`·X級`）
   - `[戰力等級提醒]`（僅已知 tier 且 ally/hostile）
 
-### 7.4 NPC lifecycle（active / archived）
+### 7.5 NPC lifecycle（active / archived）
 
 - NPC 新增欄位：
   - `lifecycle_status`：`active` / `archived`（缺省視為 `active`）
@@ -171,7 +189,7 @@
 - `_load_npcs()` 預設只回 active；需要全量時用 `include_archived=True`。
 - state.db 對 archived NPC 會打 `NPC|ARCHIVED` tag；`search_state` 預設過濾，只有 forced key（玩家明確提名）才保留。
 
-### 7.5 GM hidden plan（敘事前瞻）
+### 7.6 GM hidden plan（敘事前瞻）
 
 - 每分支可有 `branches/<bid>/gm_plan.json`（玩家不可見）。
 - 來源：`_extract_tags_async()` 的 `plan` 擷取結果（LLM 根據 GM 回覆重寫）。

--- a/doc/prompt_design.md
+++ b/doc/prompt_design.md
@@ -30,7 +30,7 @@
 - `world_lore`: 精簡 lore 摘要（非全文）
 - `npc_profiles`: 當前分支「active NPC」統計摘要（詳細檔案改由 state RAG 按需注入）
 - `team_rules`: branch config 的組隊模式規則（`free_agent` / `fixed_team`）
-- `critical_facts`: 關鍵事實區塊（phase、world day、關鍵道具、NPC 關係與 tier）
+- `critical_facts`: 關鍵事實區塊（phase、world day、關鍵道具、NPC 關係與 tier，以及 `story_anchors` 的「長期記憶」）
 - `dungeon_context`: 副本進度/節點/成長限制上下文
 
 ### 2.3 模式切換對 prompt 的影響
@@ -55,21 +55,27 @@
 
 1. `[相關世界設定]`（base lore 混合搜尋）
 2. `[相關分支設定]`（branch lore bigram 搜尋）
-3. `[相關事件追蹤]`（非 blank branch）
-4. `[GM 敘事計劃（僅供 GM 內部參考，勿透露給玩家）]`（`gm_plan.json`，非 blank branch）
+3. `[長期關鍵事件]`（sticky events，非 blank branch）
+   - 來自 `events.db.sticky_priority > 0`
+   - 依 `sticky_priority DESC, id DESC` 取最多 4 條
+   - 可包含 `resolved` 事件；用途是長期 plot pressure，不依賴當前 query 命中
+4. `[相關事件追蹤]`（query-matched active events，非 blank branch）
+   - 只取 `planted/triggered`
+   - 仍維持最多 3 條，避免和 sticky layer 混淆
+5. `[GM 敘事計劃（僅供 GM 內部參考，勿透露給玩家）]`（`gm_plan.json`，非 blank branch）
    - 顯示 `arc` + 最多 3 個 `next_beats` + 最多 2 個 `must_payoff`
    - `remaining_turns` 於注入時計算：`ttl_turns - (current_index - payoff.created_at_index)`
    - 只保留 `remaining_turns > 0` 的 payoff
    - 注入段落硬上限 `GM_PLAN_CHAR_LIMIT`（預設 500 chars）
-5. `[NPC 近期動態]`
-6. `[相關角色狀態]`（state.db 檢索結果）
+6. `[NPC 近期動態]`
+7. `[相關角色狀態]`（state.db 檢索結果）
    - 預設檢索限流：總筆數最多 30、NPC 類別最多 10
    - `must_include_keys` 命中的條目先保留，再填入一般結果
    - archived NPC 預設不注入；玩家明確提名時可透過 `must_include_keys` 召回
-7. `[戰力等級提醒]`（僅當存在 tier 已知且分類為 ally/hostile 的 NPC）
-8. `[命運走向]`（若 fate mode 開啟且非 `/gm` 指令）
-9. `---`
-10. 原始玩家輸入
+8. `[戰力等級提醒]`（僅當存在 tier 已知且分類為 ally/hostile 的 NPC）
+9. `[命運走向]`（若 fate mode 開啟且非 `/gm` 指令）
+10. `---`
+11. 原始玩家輸入
 
 補充：
 
@@ -149,14 +155,17 @@
 特點：
 
 - 使用 `call_oneshot()` 解析剛產生的 GM 內容
-- 輸出 JSON（lore/events/plan/npcs/state/time/branch_title/dungeon）
+- 輸出 JSON（lore/events/plan/npcs/state/story_anchors/time/branch_title/dungeon）
 - 只在 GM 文本長度 >= 200 時啟動
 
 ### 4.1 Prompt 內建 guardrails
 
 - lore 提取有「通用設定」門檻，避免把一次性劇情寫進知識庫
 - event 優先走 `event_ops`（id-driven），避免 title 漂移造成斷鏈
-- event create 仍保留 title dedup + status 升級規則（planted -> triggered -> resolved/abandoned）
+- event create / legacy events 仍保留 title dedup + status 升級規則（planted -> triggered -> resolved/abandoned）
+- event 可附 `sticky: true`，只用於 cross-arc plot pressure；實際寫入為 `sticky_priority=1`
+- `story_anchors` 是獨立的 identity memory layer，格式為 `{add, update, remove}`；大多數回合應輸出空物件
+- `story_anchors.update/remove` 必須 exact-match 既有 anchor，避免 extractor 漂移式改寫長期記憶
 - plan 會注入「上一輪 gm_plan 摘要」讓模型可延續或重寫；`must_payoff` 會依 `event_title` relink 到當前分支 active events
 - NPC 提取支援 `tier` 欄位；若既有 NPC 本回合無法判定 tier，應省略該欄位（不要用 null 覆蓋）
 - `_extract_tags_async()` 會在啟動時先抓當前副本 run context（`dungeon_id` + `entered_at`），並在 `_save_npc()` 時帶入，避免背景執行緒晚跑時吃到錯誤的副本來源

--- a/scripts/backfill/backfill_story_memory.py
+++ b/scripts/backfill/backfill_story_memory.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+"""Backfill story anchors and sticky events for an existing branch."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import re
+import sqlite3
+import sys
+
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+sys.path.insert(0, PROJECT_ROOT)
+
+from story_core.character_state import STORY_ANCHOR_LIMIT, _normalize_story_anchors
+from story_core.llm_bridge import call_oneshot
+
+logging.basicConfig(
+    format="[%(asctime)s] %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+    level=logging.INFO,
+)
+log = logging.getLogger("story_memory_backfill")
+
+MAX_EVENT_CONTEXT = 200
+MAX_LORE_CONTEXT = 80
+
+
+def _load_json(path: str, default):
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception:
+        return default
+
+
+def _save_json(path: str, data) -> None:
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    tmp = path + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+    os.replace(tmp, path)
+
+
+def _extract_json_payload(text: str) -> dict:
+    raw = str(text or "").strip()
+    if not raw:
+        raise ValueError("LLM returned empty response")
+    if raw.startswith("```"):
+        lines = raw.splitlines()
+        raw = "\n".join(line for line in lines if not line.startswith("```"))
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        match = re.search(r"\{.*\}", raw, re.DOTALL)
+        if not match:
+            raise
+        data = json.loads(match.group())
+    if not isinstance(data, dict):
+        raise ValueError("LLM response is not a JSON object")
+    return data
+
+
+def _story_dir(project_root: str, story_id: str) -> str:
+    return os.path.join(project_root, "data", "stories", story_id)
+
+
+def _branch_dir(project_root: str, story_id: str, branch_id: str) -> str:
+    return os.path.join(_story_dir(project_root, story_id), "branches", branch_id)
+
+
+def _branch_state_path(project_root: str, story_id: str, branch_id: str) -> str:
+    return os.path.join(_branch_dir(project_root, story_id, branch_id), "character_state.json")
+
+
+def _branch_lore_path(project_root: str, story_id: str, branch_id: str) -> str:
+    return os.path.join(_branch_dir(project_root, story_id, branch_id), "branch_lore.json")
+
+
+def _events_db_path(project_root: str, story_id: str) -> str:
+    return os.path.join(_story_dir(project_root, story_id), "events.db")
+
+
+def _get_conn(db_path: str) -> sqlite3.Connection:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _ensure_sticky_priority_column(conn: sqlite3.Connection) -> None:
+    try:
+        conn.execute("ALTER TABLE events ADD COLUMN sticky_priority INTEGER NOT NULL DEFAULT 0")
+        conn.commit()
+    except sqlite3.OperationalError:
+        pass
+
+
+def _normalize_sticky_priority(value: object) -> int:
+    try:
+        priority = int(value or 0)
+    except (TypeError, ValueError):
+        priority = 0
+    return max(0, min(3, priority))
+
+
+def _load_branch_events(project_root: str, story_id: str, branch_id: str) -> list[dict]:
+    db_path = _events_db_path(project_root, story_id)
+    if not os.path.exists(db_path):
+        return []
+    conn = _get_conn(db_path)
+    _ensure_sticky_priority_column(conn)
+    rows = conn.execute(
+        """
+        SELECT id, event_type, title, description, status, tags, related_titles, message_index, sticky_priority
+        FROM events
+        WHERE branch_id = ?
+        ORDER BY id
+        """,
+        (branch_id,),
+    ).fetchall()
+    conn.close()
+    return [dict(row) for row in rows]
+
+
+def _format_event_context(events: list[dict]) -> str:
+    if not events:
+        return "（無事件）"
+    lines = []
+    for event in events[:MAX_EVENT_CONTEXT]:
+        lines.append(
+            json.dumps(
+                {
+                    "id": event.get("id"),
+                    "type": event.get("event_type", ""),
+                    "title": event.get("title", ""),
+                    "status": event.get("status", ""),
+                    "sticky_priority": _normalize_sticky_priority(event.get("sticky_priority")),
+                    "tags": event.get("tags", ""),
+                    "description": str(event.get("description", ""))[:220],
+                },
+                ensure_ascii=False,
+            )
+        )
+    if len(events) > MAX_EVENT_CONTEXT:
+        lines.append(f"（其餘省略 {len(events) - MAX_EVENT_CONTEXT} 筆事件）")
+    return "\n".join(lines)
+
+
+def _format_lore_context(branch_lore: list[dict]) -> str:
+    if not branch_lore:
+        return "（無分支 lore）"
+    lines = []
+    for entry in branch_lore[:MAX_LORE_CONTEXT]:
+        lines.append(
+            json.dumps(
+                {
+                    "category": entry.get("category", ""),
+                    "subcategory": entry.get("subcategory", ""),
+                    "topic": entry.get("topic", ""),
+                    "content": str(entry.get("content", ""))[:260],
+                },
+                ensure_ascii=False,
+            )
+        )
+    if len(branch_lore) > MAX_LORE_CONTEXT:
+        lines.append(f"（其餘省略 {len(branch_lore) - MAX_LORE_CONTEXT} 筆 lore）")
+    return "\n".join(lines)
+
+
+def _summarize_state(state: dict) -> dict:
+    inventory = state.get("inventory", {})
+    inventory_sample = inventory
+    if isinstance(inventory, dict):
+        inventory_sample = dict(list(inventory.items())[:15])
+    elif isinstance(inventory, list):
+        inventory_sample = inventory[:15]
+    return {
+        "name": state.get("name"),
+        "current_phase": state.get("current_phase"),
+        "current_status": state.get("current_status"),
+        "gene_lock": state.get("gene_lock"),
+        "systems": state.get("systems", {}),
+        "relationships": state.get("relationships", {}),
+        "completed_missions": state.get("completed_missions", []),
+        "inventory_sample": inventory_sample,
+        "story_anchors": _normalize_story_anchors(state.get("story_anchors", [])),
+    }
+
+
+def _build_anchor_prompt(story_id: str, branch_id: str, state: dict, branch_lore: list[dict], events: list[dict]) -> str:
+    return (
+        "你是故事長期記憶整理器。請根據既有 branch 資料，整理應常駐於 system prompt 的 story_anchors。\n\n"
+        f"## Story\nstory_id={story_id}\nbranch_id={branch_id}\n\n"
+        "## 任務\n"
+        "輸出 0-10 條短句 story_anchors。這些錨點是身份層永久事實，只能涵蓋以下 4 類：\n"
+        "1. 長期主線\n"
+        "2. 核心隊伍關係\n"
+        "3. 永久代價 / 不可逆變化\n"
+        "4. 長期宿敵 / 契約 / 追索壓力（前提是它已經成為角色身份的一部分）\n\n"
+        "不要輸出單純 plot pressure；那種交給 sticky events。\n"
+        "不要輸出場景細節、一次性事件、暫時狀態、純 inventory 細節。\n"
+        "每條錨點請寫成 8-40 字的簡短 bullet 文本，不要編號。\n\n"
+        f"## 角色狀態摘要\n{json.dumps(_summarize_state(state), ensure_ascii=False, indent=2)}\n\n"
+        f"## 分支 Lore\n{_format_lore_context(branch_lore)}\n\n"
+        f"## 分支事件\n{_format_event_context(events)}\n\n"
+        "## 輸出格式\n"
+        "只輸出 JSON：\n"
+        '{"story_anchors": ["錨點1", "錨點2"]}\n'
+    )
+
+
+def _build_sticky_prompt(story_id: str, branch_id: str, state: dict, current_anchors: list[str], events: list[dict]) -> str:
+    return (
+        "你是故事事件記憶標註器。請從既有 branch events 中找出應該每回合常駐注入的 sticky events。\n\n"
+        f"## Story\nstory_id={story_id}\nbranch_id={branch_id}\n\n"
+        "## Sticky 事件定義\n"
+        "只標記 cross-arc plot pressure：\n"
+        "- 跨弧線的外部威脅 / 追索\n"
+        "- 未解的契約 / 承諾\n"
+        "- 仍在影響當前劇情的長期伏筆\n\n"
+        "不要標記 identity facts；那些已經由 story_anchors 負責。\n"
+        "大多數事件都不該是 sticky。最多挑 4 條，並給 priority 1-3。\n"
+        "3 = 幾乎每回合都該提醒，2 = 高優先，1 = 一般長期提醒。\n\n"
+        f"## 現有 story_anchors\n{json.dumps(current_anchors, ensure_ascii=False, indent=2)}\n\n"
+        f"## 角色狀態摘要\n{json.dumps(_summarize_state(state), ensure_ascii=False, indent=2)}\n\n"
+        f"## 分支事件\n{_format_event_context(events)}\n\n"
+        "## 輸出格式\n"
+        "只輸出 JSON：\n"
+        '{"sticky_events": [{"id": 123, "sticky_priority": 3, "reason": "仍在跨弧線追索主角"}]}\n'
+    )
+
+
+def _propose_story_anchors(story_id: str, branch_id: str, state: dict, branch_lore: list[dict], events: list[dict]) -> list[str]:
+    prompt = _build_anchor_prompt(story_id, branch_id, state, branch_lore, events)
+    data = _extract_json_payload(call_oneshot(prompt))
+    return _normalize_story_anchors(data.get("story_anchors", []), limit=STORY_ANCHOR_LIMIT)
+
+
+def _propose_sticky_events(story_id: str, branch_id: str, state: dict, anchors: list[str], events: list[dict]) -> list[dict]:
+    prompt = _build_sticky_prompt(story_id, branch_id, state, anchors, events)
+    data = _extract_json_payload(call_oneshot(prompt))
+    proposals = []
+    valid_ids = {event.get("id") for event in events if isinstance(event.get("id"), int)}
+    seen_ids = set()
+    for item in data.get("sticky_events", []):
+        if not isinstance(item, dict):
+            continue
+        event_id = item.get("id")
+        if isinstance(event_id, str) and event_id.isdigit():
+            event_id = int(event_id)
+        if not isinstance(event_id, int) or event_id not in valid_ids or event_id in seen_ids:
+            continue
+        seen_ids.add(event_id)
+        proposals.append(
+            {
+                "id": event_id,
+                "sticky_priority": _normalize_sticky_priority(item.get("sticky_priority")),
+                "reason": str(item.get("reason", "")).strip(),
+            }
+        )
+    proposals = [item for item in proposals if item["sticky_priority"] > 0]
+    proposals.sort(key=lambda item: (item["sticky_priority"], item["id"]), reverse=True)
+    return proposals[:4]
+
+
+def _apply_story_anchors(project_root: str, story_id: str, branch_id: str, anchors: list[str]) -> None:
+    path = _branch_state_path(project_root, story_id, branch_id)
+    state = _load_json(path, {})
+    state["story_anchors"] = _normalize_story_anchors(anchors, limit=STORY_ANCHOR_LIMIT)
+    _save_json(path, state)
+
+
+def _apply_sticky_events(project_root: str, story_id: str, branch_id: str, proposals: list[dict]) -> None:
+    db_path = _events_db_path(project_root, story_id)
+    if not os.path.exists(db_path):
+        return
+    conn = _get_conn(db_path)
+    _ensure_sticky_priority_column(conn)
+    conn.execute("UPDATE events SET sticky_priority = 0 WHERE branch_id = ?", (branch_id,))
+    for item in proposals:
+        conn.execute(
+            "UPDATE events SET sticky_priority = ? WHERE branch_id = ? AND id = ?",
+            (item["sticky_priority"], branch_id, item["id"]),
+        )
+    conn.commit()
+    conn.close()
+
+
+def _print_proposal(anchors_before: list[str], anchors_after: list[str], sticky: list[dict], event_title_map: dict[int, str]) -> None:
+    print("=== Proposed Story Anchors ===")
+    if anchors_after:
+        for anchor in anchors_after:
+            marker = "=" if anchor in anchors_before else "+"
+            print(f"{marker} {anchor}")
+    else:
+        print("(none)")
+
+    print("\n=== Proposed Sticky Events ===")
+    if sticky:
+        for item in sticky:
+            title = event_title_map.get(item["id"], f"#{item['id']}")
+            reason = f" | {item['reason']}" if item.get("reason") else ""
+            print(f"P{item['sticky_priority']} #{item['id']} {title}{reason}")
+    else:
+        print("(none)")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Backfill story anchors and sticky events for a branch")
+    parser.add_argument("--story-id", required=True, help="Target story_id")
+    parser.add_argument("--branch-id", required=True, help="Target branch_id")
+    parser.add_argument("--project-root", default=PROJECT_ROOT, help="Project root containing data/stories")
+    parser.add_argument("--dry-run", action="store_true", help="Show proposed anchors/sticky events without writing")
+    args = parser.parse_args()
+
+    project_root = os.path.abspath(args.project_root)
+    branch_dir = _branch_dir(project_root, args.story_id, args.branch_id)
+    state_path = _branch_state_path(project_root, args.story_id, args.branch_id)
+    if not os.path.isdir(branch_dir):
+        log.error("branch not found: %s", branch_dir)
+        return 1
+    if not os.path.exists(state_path):
+        log.error("character_state.json not found: %s", state_path)
+        return 1
+
+    state = _load_json(state_path, {})
+    branch_lore = _load_json(_branch_lore_path(project_root, args.story_id, args.branch_id), [])
+    events = _load_branch_events(project_root, args.story_id, args.branch_id)
+    current_anchors = _normalize_story_anchors(state.get("story_anchors", []), limit=STORY_ANCHOR_LIMIT)
+
+    log.info(
+        "building story memory proposals for %s/%s (%d events, %d lore entries)",
+        args.story_id,
+        args.branch_id,
+        len(events),
+        len(branch_lore),
+    )
+    proposed_anchors = _propose_story_anchors(args.story_id, args.branch_id, state, branch_lore, events)
+    proposed_sticky = _propose_sticky_events(
+        args.story_id,
+        args.branch_id,
+        state,
+        proposed_anchors,
+        events,
+    )
+
+    event_title_map = {event["id"]: event.get("title", "") for event in events if isinstance(event.get("id"), int)}
+    _print_proposal(current_anchors, proposed_anchors, proposed_sticky, event_title_map)
+
+    if args.dry_run:
+        print("\nDry run only. Re-run without --dry-run to apply.")
+        return 0
+
+    _apply_story_anchors(project_root, args.story_id, args.branch_id, proposed_anchors)
+    _apply_sticky_events(project_root, args.story_id, args.branch_id, proposed_sticky)
+    print("\nApplied story anchors and sticky events.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/story_core/app_helpers.py
+++ b/story_core/app_helpers.py
@@ -22,7 +22,8 @@ from story_core import usage_db
 from story_core.event_db import (
     insert_event, search_relevant_events, get_events, get_event_by_id,
     update_event_status, search_events as search_events_db,
-    get_active_events,
+    get_active_events, get_sticky_events, format_sticky_events,
+    update_event_sticky_priority,
     copy_events_for_fork, merge_events_into, delete_events_for_branch,
 )
 from story_core.image_gen import generate_image_async, get_image_status, get_image_path

--- a/story_core/character_state.py
+++ b/story_core/character_state.py
@@ -59,10 +59,36 @@ _TEAM_RULES = {
     ),
 }
 _STATE_CORE_EXTRA_KEYS = ("base_power_level", "health", "spirit_status")
+STORY_ANCHOR_LIMIT = 10
 
 
 def _is_numeric_value(value: object) -> bool:
     return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _normalize_story_anchor_text(value: object) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return ""
+    text = re.sub(r"^[\-\*\u2022\u2027]+\s*", "", text)
+    text = re.sub(r"\s+", " ", text)
+    return text[:160].strip()
+
+
+def _normalize_story_anchors(raw_anchors: object, limit: int = STORY_ANCHOR_LIMIT) -> list[str]:
+    if not isinstance(raw_anchors, list):
+        return []
+    normalized = []
+    seen = set()
+    for item in raw_anchors:
+        text = _normalize_story_anchor_text(item)
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        normalized.append(text)
+        if len(normalized) >= limit:
+            break
+    return normalized
 
 
 def _load_nsfw_preferences(story_id: str) -> dict:
@@ -117,6 +143,7 @@ def _blank_character_state(story_id: str) -> dict:
             state[key] = {}
         else:
             state[key] = []
+    state["story_anchors"] = []
     return state
 
 
@@ -165,6 +192,14 @@ def _load_character_state(story_id: str, branch_id: str = "main") -> dict:
             state[key] = _migrate_list_to_map(value)
             dirty = True
             log.info("    auto-migrate: converted %s from list to map in %s/%s", key, story_id, branch_id)
+
+    anchors = _normalize_story_anchors(state.get("story_anchors", []))
+    if anchors != state.get("story_anchors"):
+        state["story_anchors"] = anchors
+        dirty = True
+    elif "story_anchors" not in state:
+        state["story_anchors"] = []
+        dirty = True
 
     needs_persist = dirty or not os.path.exists(path)
     if dirty:
@@ -244,6 +279,13 @@ def _build_critical_facts(story_id: str, branch_id: str, state: dict, npcs: list
     elif relationships:
         rel_parts = [f"{name}（{_rel_to_str(rel)}）" for name, rel in relationships.items()]
         lines.append(f"- 人際關係：{'、'.join(rel_parts)}")
+
+    anchors = _normalize_story_anchors(state.get("story_anchors", []))
+    if anchors:
+        lines.append("")
+        lines.append("### 長期記憶")
+        for anchor in anchors[:STORY_ANCHOR_LIMIT]:
+            lines.append(f"- {anchor}")
 
     if not lines:
         return "（尚無關鍵事實記錄）"
@@ -420,6 +462,8 @@ __all__ = [
     "_blank_character_state",
     "_load_character_state",
     "_TEAM_RULES",
+    "STORY_ANCHOR_LIMIT",
+    "_normalize_story_anchors",
     "_build_critical_facts",
     "_format_state_core_value",
     "_build_core_state_text",

--- a/story_core/event_db.py
+++ b/story_core/event_db.py
@@ -29,6 +29,44 @@ def _get_conn(story_id: str) -> sqlite3.Connection:
 # Schema
 # ---------------------------------------------------------------------------
 
+_STATUS_LABELS = {
+    "planted": "已埋",
+    "triggered": "已觸發",
+    "resolved": "已解決",
+    "abandoned": "已廢棄",
+}
+
+
+def _parse_sticky_flag(raw_flag: object) -> bool | None:
+    if raw_flag is None:
+        return None
+    if isinstance(raw_flag, bool):
+        return raw_flag
+    if isinstance(raw_flag, (int, float)):
+        return raw_flag != 0
+    if isinstance(raw_flag, str):
+        value = raw_flag.strip().lower()
+        if value in {"", "none", "null"}:
+            return None
+        if value in {"1", "true", "yes", "y", "on"}:
+            return True
+        if value in {"0", "false", "no", "n", "off"}:
+            return False
+    return bool(raw_flag)
+
+
+def _normalize_sticky_priority(raw_priority: object, raw_sticky: object | None = None) -> int:
+    if raw_priority is None:
+        sticky_flag = _parse_sticky_flag(raw_sticky)
+        if sticky_flag is not None:
+            raw_priority = 1 if sticky_flag else 0
+    try:
+        priority = int(raw_priority or 0)
+    except (TypeError, ValueError):
+        priority = 0
+    return max(0, min(3, priority))
+
+
 def _ensure_tables(conn: sqlite3.Connection):
     conn.executescript("""
         CREATE TABLE IF NOT EXISTS events (
@@ -41,9 +79,14 @@ def _ensure_tables(conn: sqlite3.Connection):
             status          TEXT NOT NULL DEFAULT 'planted',
             tags            TEXT NOT NULL DEFAULT '',
             related_titles  TEXT NOT NULL DEFAULT '',
-            created_at      TEXT NOT NULL
+            created_at      TEXT NOT NULL,
+            sticky_priority INTEGER NOT NULL DEFAULT 0
         );
     """)
+    try:
+        conn.execute("ALTER TABLE events ADD COLUMN sticky_priority INTEGER NOT NULL DEFAULT 0")
+    except sqlite3.OperationalError:
+        pass
 
 
 # ---------------------------------------------------------------------------
@@ -56,10 +99,14 @@ def insert_event(story_id: str, event: dict, branch_id: str) -> int:
     _ensure_tables(conn)
 
     now = datetime.now(timezone.utc).isoformat()
+    sticky_priority = _normalize_sticky_priority(
+        event.get("sticky_priority"),
+        event.get("sticky"),
+    )
     cur = conn.execute(
         """INSERT INTO events (event_type, title, description, message_index,
-           branch_id, status, tags, related_titles, created_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+           branch_id, status, tags, related_titles, created_at, sticky_priority)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (
             event.get("event_type", "遭遇"),
             event.get("title", ""),
@@ -70,6 +117,7 @@ def insert_event(story_id: str, event: dict, branch_id: str) -> int:
             event.get("tags", ""),
             event.get("related_titles", ""),
             now,
+            sticky_priority,
         ),
     )
     conn.commit()
@@ -83,6 +131,18 @@ def update_event_status(story_id: str, event_id: int, new_status: str):
     conn = _get_conn(story_id)
     _ensure_tables(conn)
     conn.execute("UPDATE events SET status = ? WHERE id = ?", (new_status, event_id))
+    conn.commit()
+    conn.close()
+
+
+def update_event_sticky_priority(story_id: str, event_id: int, sticky_priority: int):
+    """Update an event's sticky priority (0-3)."""
+    conn = _get_conn(story_id)
+    _ensure_tables(conn)
+    conn.execute(
+        "UPDATE events SET sticky_priority = ? WHERE id = ?",
+        (_normalize_sticky_priority(sticky_priority), event_id),
+    )
     conn.commit()
     conn.close()
 
@@ -132,7 +192,7 @@ def copy_events_for_fork(story_id: str, source_branch_id: str, target_branch_id:
     if branch_point_index is None:
         rows = conn.execute(
             """SELECT event_type, title, description, message_index,
-               status, tags, related_titles, created_at
+               status, tags, related_titles, created_at, sticky_priority
                FROM events
                WHERE branch_id = ?
                ORDER BY id""",
@@ -141,7 +201,7 @@ def copy_events_for_fork(story_id: str, source_branch_id: str, target_branch_id:
     else:
         rows = conn.execute(
             """SELECT event_type, title, description, message_index,
-               status, tags, related_titles, created_at
+               status, tags, related_titles, created_at, sticky_priority
                FROM events
                WHERE branch_id = ?
                  AND (message_index <= ? OR message_index IS NULL)
@@ -155,8 +215,8 @@ def copy_events_for_fork(story_id: str, source_branch_id: str, target_branch_id:
 
     conn.executemany(
         """INSERT INTO events (event_type, title, description, message_index,
-           branch_id, status, tags, related_titles, created_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+           branch_id, status, tags, related_titles, created_at, sticky_priority)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         [
             (
                 row["event_type"],
@@ -168,6 +228,7 @@ def copy_events_for_fork(story_id: str, source_branch_id: str, target_branch_id:
                 row["tags"],
                 row["related_titles"],
                 row["created_at"],
+                _normalize_sticky_priority(row["sticky_priority"]),
             )
             for row in rows
         ],
@@ -190,7 +251,7 @@ def merge_events_into(story_id: str, src_branch_id: str, dst_branch_id: str):
 
     src_rows = conn.execute(
         """SELECT event_type, title, description, message_index,
-           status, tags, related_titles, created_at
+           status, tags, related_titles, created_at, sticky_priority
            FROM events
            WHERE branch_id = ?
            ORDER BY id""",
@@ -201,10 +262,16 @@ def merge_events_into(story_id: str, src_branch_id: str, dst_branch_id: str):
         return
 
     dst_rows = conn.execute(
-        "SELECT id, title FROM events WHERE branch_id = ?",
+        "SELECT id, title, sticky_priority FROM events WHERE branch_id = ?",
         (dst_branch_id,),
     ).fetchall()
-    dst_title_to_id = {row["title"]: row["id"] for row in dst_rows}
+    dst_title_to_meta = {
+        row["title"]: {
+            "id": row["id"],
+            "sticky_priority": _normalize_sticky_priority(row["sticky_priority"]),
+        }
+        for row in dst_rows
+    }
 
     # Keep latest src row per title in case src contains historical duplicates.
     src_by_title = {}
@@ -214,8 +281,8 @@ def merge_events_into(story_id: str, src_branch_id: str, dst_branch_id: str):
     inserts = []
     updates = []
     for title, row in src_by_title.items():
-        dst_id = dst_title_to_id.get(title)
-        if dst_id is None:
+        dst_meta = dst_title_to_meta.get(title)
+        if dst_meta is None:
             inserts.append(
                 (
                     row["event_type"],
@@ -227,21 +294,28 @@ def merge_events_into(story_id: str, src_branch_id: str, dst_branch_id: str):
                     row["tags"],
                     row["related_titles"],
                     row["created_at"],
+                    _normalize_sticky_priority(row["sticky_priority"]),
                 )
             )
         else:
-            updates.append((row["status"], dst_id))
+            updates.append(
+                (
+                    row["status"],
+                    _normalize_sticky_priority(row["sticky_priority"]),
+                    dst_meta["id"],
+                )
+            )
 
     if inserts:
         conn.executemany(
             """INSERT INTO events (event_type, title, description, message_index,
-               branch_id, status, tags, related_titles, created_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+               branch_id, status, tags, related_titles, created_at, sticky_priority)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             inserts,
         )
     if updates:
         conn.executemany(
-            "UPDATE events SET status = ? WHERE id = ?",
+            "UPDATE events SET status = ?, sticky_priority = ? WHERE id = ?",
             updates,
         )
 
@@ -319,8 +393,41 @@ def search_relevant_events(story_id: str, user_message: str, branch_id: str, lim
 
     lines = ["[相關事件追蹤]"]
     for e in results:
-        status_label = {"planted": "已埋", "triggered": "已觸發", "resolved": "已解決", "abandoned": "已廢棄"}.get(e["status"], e["status"])
+        status_label = _STATUS_LABELS.get(e["status"], e["status"])
         lines.append(f"- [{e['event_type']}] {e['title']}（{status_label}）：{e['description'][:200]}")
+    return "\n".join(lines)
+
+
+def get_sticky_events(story_id: str, branch_id: str, limit: int = 4) -> list[dict]:
+    """Return always-on sticky events for prompt injection."""
+    conn = _get_conn(story_id)
+    _ensure_tables(conn)
+    rows = conn.execute(
+        """
+        SELECT *
+        FROM events
+        WHERE branch_id = ? AND sticky_priority > 0
+        ORDER BY sticky_priority DESC, id DESC
+        LIMIT ?
+        """,
+        (branch_id, limit),
+    ).fetchall()
+    results = [dict(r) for r in rows]
+    conn.close()
+    return results
+
+
+def format_sticky_events(story_id: str, branch_id: str, limit: int = 4) -> str:
+    """Return formatted always-on sticky events for GM prompt injection."""
+    results = get_sticky_events(story_id, branch_id, limit=limit)
+    if not results:
+        return ""
+    lines = ["[長期關鍵事件]"]
+    for event in results:
+        status_label = _STATUS_LABELS.get(event["status"], event["status"])
+        lines.append(
+            f"- [{event['event_type']}] {event['title']}（{status_label}）：{event['description'][:200]}"
+        )
     return "\n".join(lines)
 
 
@@ -341,9 +448,16 @@ def get_event_title_map(story_id: str, branch_id: str) -> dict[str, dict]:
     conn = _get_conn(story_id)
     _ensure_tables(conn)
     rows = conn.execute(
-        "SELECT id, title, status FROM events WHERE branch_id = ?", (branch_id,)
+        "SELECT id, title, status, sticky_priority FROM events WHERE branch_id = ?", (branch_id,)
     ).fetchall()
-    result = {r["title"]: {"id": r["id"], "status": r["status"]} for r in rows}
+    result = {
+        r["title"]: {
+            "id": r["id"],
+            "status": r["status"],
+            "sticky_priority": _normalize_sticky_priority(r["sticky_priority"]),
+        }
+        for r in rows
+    }
     conn.close()
     return result
 

--- a/story_core/gm_pipeline.py
+++ b/story_core/gm_pipeline.py
@@ -7,7 +7,13 @@ import re
 import threading
 import time
 
-from story_core.state_updates import _EVENT_STATUS_ORDER, _INSTRUCTION_KEYS, _SCENE_KEYS, _is_numeric_value
+from story_core.state_updates import (
+    _EVENT_STATUS_ORDER,
+    _INSTRUCTION_KEYS,
+    _SCENE_KEYS,
+    _is_numeric_value,
+    _normalize_event_sticky_priority,
+)
 
 log = logging.getLogger("rpg")
 
@@ -16,6 +22,71 @@ def _app():
     import app as app_module
 
     return app_module
+
+
+def _normalize_story_anchor_value(app_module, value: object) -> str:
+    normalized = app_module._normalize_story_anchors([value], limit=1)
+    return normalized[0] if normalized else ""
+
+
+def _apply_story_anchor_ops(story_id: str, branch_id: str, raw_ops: object) -> tuple[list[str], list[str]] | None:
+    app_module = _app()
+
+    if not isinstance(raw_ops, dict):
+        return None
+
+    raw_add = raw_ops.get("add")
+    raw_update = raw_ops.get("update")
+    raw_remove = raw_ops.get("remove")
+    if not isinstance(raw_add, list) and not isinstance(raw_update, list) and not isinstance(raw_remove, list):
+        return None
+
+    state = app_module._load_character_state(story_id, branch_id)
+    before = app_module._normalize_story_anchors(state.get("story_anchors", []))
+    anchors = list(before)
+
+    remove_set = set()
+    if isinstance(raw_remove, list):
+        for item in raw_remove:
+            text = _normalize_story_anchor_value(app_module, item)
+            if text:
+                remove_set.add(text)
+    if remove_set:
+        anchors = [anchor for anchor in anchors if anchor not in remove_set]
+
+    replacements: dict[str, str] = {}
+    if isinstance(raw_update, list):
+        existing_anchor_set = set(anchors)
+        for item in raw_update:
+            if not isinstance(item, dict):
+                continue
+            old_text = _normalize_story_anchor_value(app_module, item.get("old"))
+            new_text = _normalize_story_anchor_value(app_module, item.get("new"))
+            if not old_text or not new_text or old_text == new_text:
+                continue
+            if old_text in existing_anchor_set:
+                replacements[old_text] = new_text
+    if replacements:
+        anchors = [replacements.get(anchor, anchor) for anchor in anchors]
+
+    additions: list[str] = []
+    if isinstance(raw_add, list):
+        for item in raw_add:
+            text = _normalize_story_anchor_value(app_module, item)
+            if text:
+                additions.append(text)
+
+    after = app_module._normalize_story_anchors([*anchors, *additions])
+    if after == before:
+        return None
+
+    state["story_anchors"] = after
+    app_module._save_json(app_module._story_character_state_path(story_id, branch_id), state)
+    log.info(
+        "    story_anchors: %s",
+        json.dumps({"before": before, "after": after}, ensure_ascii=False),
+    )
+    return before, after
 
 
 def _validate_state_update(update: dict, schema: dict, current_state: dict) -> tuple[dict, list[dict]]:
@@ -427,6 +498,8 @@ def _extract_tags_async(
 
             state = app_module._load_character_state(story_id, branch_id)
             existing_state_keys = ", ".join(sorted(state.keys()))
+            current_story_anchors = app_module._normalize_story_anchors(state.get("story_anchors", []))
+            story_anchors_text = "\n".join(f"- {anchor}" for anchor in current_story_anchors) if current_story_anchors else "（無）"
 
             list_contents_lines = []
             for list_def in schema.get("lists", []):
@@ -475,11 +548,13 @@ def _extract_tags_async(
                 "* `resolved`（解決）：必須是該事件的目標已徹底完成或因故徹底終結。\n"
                 "優先輸出 `event_ops`（用 id 更新，避免 title 漂移）：\n"
                 f"{active_events_text}\n"
-                "- update：已有事件狀態變化（如伏筆被觸發、事件被解決）時，輸出 id + status\n"
-                "- create：只有真的新事件才建立（title 不要跟現有事件只差幾個字）\n"
-                'event_ops 格式：{"update": [{"id": 123, "status": "triggered"}], "create": [{"event_type": "類型", "title": "標題", "description": "描述", "status": "planted", "tags": "關鍵字"}]}\n'
+                "- `sticky` 只用於跨弧線 plot pressure：外部威脅/追索、未解契約/承諾、仍在影響劇情的長期伏筆。**身份事實不要放在 events，改放 story_anchors。**\n"
+                "- 大多數事件都不是 sticky；只有真正需要長期常駐提醒的事件才標 `sticky: true`\n"
+                "- update：已有事件狀態變化（如伏筆被觸發、事件被解決）時，輸出 id + status；若這個事件已成為長期劇情壓力，也可加 `sticky`\n"
+                "- create：只有真的新事件才建立（title 不要跟現有事件只差幾個字）；sticky 事件仍然必須是 plot pressure，不可和 story_anchors 重複\n"
+                'event_ops 格式：{"update": [{"id": 123, "status": "triggered", "sticky": true}], "create": [{"event_type": "類型", "title": "標題", "description": "描述", "status": "planted", "tags": "關鍵字", "sticky": true}]}\n'
                 "- 相容：若你無法使用 event id，才改用 legacy `events` 陣列格式。\n"
-                'legacy events 格式：[{"event_type": "類型", "title": "標題", "description": "描述", "status": "planted", "tags": "關鍵字"}]\n'
+                'legacy events 格式：[{"event_type": "類型", "title": "標題", "description": "描述", "status": "planted", "tags": "關鍵字", "sticky": true}]\n'
                 "可用類型：伏筆/轉折/遭遇/發現/戰鬥/獲得/觸發\n"
                 "可用狀態：planted/triggered/resolved/abandoned（可用同義詞如 ongoing/completed，系統會正規化）\n\n"
                 "## 3. GM 敘事計劃（plan）\n"
@@ -543,13 +618,24 @@ def _extract_tags_async(
                 "- list_add/list_remove：list 型欄位增減\n"
                 "- 相容：若你無法輸出 state_ops，才輸出 legacy `state` 物件。\n"
                 "格式：state/state_ops 只填有變化的欄位。\n\n"
-                "## 6. 時間流逝（time）\n"
+                "## 6. 長期記憶（story_anchors）\n"
+                "提取角色/隊伍/故事的**身份層永久事實**。這些內容會常駐進 system prompt，必須非常保守。\n"
+                "只允許 4 類：長期主線、核心隊伍關係、永久代價/不可逆變化、長期宿敵/契約/追索壓力。\n"
+                "不要把單純 plot pressure 放進 story_anchors；那種放到 sticky events。\n"
+                f"目前 story_anchors：\n{story_anchors_text}\n"
+                "規則：\n"
+                "- `add`：只加入 genuinely new 的跨弧線永久事實\n"
+                "- `update`：只有既有 anchor 被故事**明確推翻或明確升級**時才用，而且 old 必須和現有 anchor 完全一致\n"
+                "- `remove`：只有該事實被故事**明確否定**時才用，而且文字必須和現有 anchor 完全一致\n"
+                "- 大多數回合應該輸出空的 `story_anchors: {}`\n"
+                '格式：{"add": ["新 anchor"], "update": [{"old": "舊 anchor", "new": "新 anchor"}], "remove": ["舊 anchor"]}\n\n'
+                "## 7. 時間流逝（time）\n"
                 "估算這段敘事中經過了多少時間。包含明確跳躍和隱含的時間流逝。\n"
                 "- 明確跳躍：「三天後」→ days:3、「那天深夜」→ hours:8、「半個月的苦練」→ days:15\n"
                 "- 隱含流逝參考：一場小戰鬥 → hours:1、大型戰役/Boss戰 → hours:3、探索建築/區域 → hours:2、長途移動/趕路 → hours:4、休息/過夜 → hours:8、訓練/修煉 → days:1\n"
                 "- 純對話/短暫互動/思考/角色創建/主神空間閒聊不需要輸出。只有場景中有實際行動推進才估算。\n"
                 '格式：{"days": N} 或 {"hours": N}（只選一種，優先用 days）\n\n'
-                "## 7. 分支標題（branch_title）\n"
+                "## 8. 分支標題（branch_title）\n"
                 "用 4-8 個中文字總結這段 GM 回覆中**玩家的核心行動或場景轉折**。\n"
                 "例如：「七首殺屍測試」「巷道右側突圍」「自省之眼覺醒」「進入蜀山副本」「商城兌換裝備」\n"
                 "要求：動作導向、簡潔、不帶標點符號。\n"
@@ -565,7 +651,7 @@ def _extract_tags_async(
                     nodes_mapping = ", ".join([f"{node['id']}=「{node['title']}」" for node in node_list])
                     areas_str = ", ".join([area["id"] for area in template.get("areas", [])])
                     prompt += (
-                        f"## 8. 副本進度（dungeon）\n"
+                        f"## 9. 副本進度（dungeon）\n"
                         f"當前在副本【{template['name']}】中。分析 GM 文本中是否存在：\n"
                         f"- 主線劇情節點的完成（如「成功封印伽椰子」）\n"
                         f"- 新區域的發現或探索（如「進入二樓」、「深入地下室」）\n\n"
@@ -589,7 +675,7 @@ def _extract_tags_async(
             prompt += (
                 "## 輸出\n"
                 "JSON 物件，只包含有內容的類型：\n"
-                '{"lore": [...], "event_ops": {"update": [...], "create": [...]}, "events": [...], "plan": {...}, "npcs": [...], "state_ops": {...}, "state": {...}, "time": {"days": N}, "branch_title": "...", "dungeon": {...}}\n'
+                '{"lore": [...], "event_ops": {"update": [...], "create": [...]}, "events": [...], "plan": {...}, "npcs": [...], "state_ops": {...}, "state": {...}, "story_anchors": {"add": [...], "update": [...], "remove": [...]}, "time": {"days": N}, "branch_title": "...", "dungeon": {...}}\n'
                 "沒有新資訊的類型省略或用空陣列/空物件。只輸出 JSON。"
             )
 
@@ -633,7 +719,14 @@ def _extract_tags_async(
             if not isinstance(data, dict):
                 return
 
-            saved_counts = {"lore": 0, "events": 0, "npcs": 0, "state": False, "plan": "no change"}
+            saved_counts = {
+                "lore": 0,
+                "events": 0,
+                "npcs": 0,
+                "state": False,
+                "anchors": "no change",
+                "plan": "no change",
+            }
 
             pistol = app_module.get_pistol_mode(app_module._story_dir(story_id), branch_id)
             if pistol:
@@ -688,17 +781,28 @@ def _extract_tags_async(
                         if not title:
                             continue
                         new_status = app_module._normalize_event_status(event.get("status")) or "planted"
+                        sticky_priority = _normalize_event_sticky_priority(
+                            event.get("sticky_priority"),
+                            event.get("sticky"),
+                            default=0,
+                        ) or 0
                         if title not in existing_titles:
                             event["message_index"] = msg_index
                             event["status"] = new_status
+                            event["sticky_priority"] = sticky_priority
                             new_id = app_module.insert_event(story_id, event, branch_id)
                             existing_titles.add(title)
-                            existing_title_map[title] = {"id": new_id, "status": new_status}
+                            existing_title_map[title] = {
+                                "id": new_id,
+                                "status": new_status,
+                                "sticky_priority": sticky_priority,
+                            }
                             saved_counts["events"] += 1
                         else:
                             existing = existing_title_map.get(title, {})
                             old_status = app_module._normalize_event_status(existing.get("status")) or str(existing.get("status", "")).strip()
                             event_id = existing.get("id")
+                            old_sticky_priority = int(existing.get("sticky_priority") or 0)
                             if (
                                 isinstance(event_id, int)
                                 and _EVENT_STATUS_ORDER.get(new_status, -1)
@@ -706,6 +810,10 @@ def _extract_tags_async(
                             ):
                                 app_module.update_event_status(story_id, event_id, new_status)
                                 existing_title_map[title]["status"] = new_status
+                                saved_counts["events"] += 1
+                            if isinstance(event_id, int) and sticky_priority > old_sticky_priority:
+                                app_module.update_event_sticky_priority(story_id, event_id, sticky_priority)
+                                existing_title_map[title]["sticky_priority"] = sticky_priority
                                 saved_counts["events"] += 1
 
             if pistol:
@@ -753,6 +861,11 @@ def _extract_tags_async(
                         state_applied = True
                 saved_counts["state"] = state_applied
 
+            anchor_change = _apply_story_anchor_ops(story_id, branch_id, data.get("story_anchors"))
+            if anchor_change is not None:
+                _before, after = anchor_change
+                saved_counts["anchors"] = f"updated ({len(after)})"
+
             time_data = data.get("time", {})
             if time_data and isinstance(time_data, dict) and not skip_time:
                 days = time_data.get("days") or 0
@@ -796,11 +909,12 @@ def _extract_tags_async(
                     saved_counts["dungeon_area"] = True
 
             log.info(
-                "    extract_tags: saved %d lore, %d events, %d npcs, state %s, time %s, title %s, plan %s, dungeon %s",
+                "    extract_tags: saved %d lore, %d events, %d npcs, state %s, anchors %s, time %s, title %s, plan %s, dungeon %s",
                 saved_counts["lore"],
                 saved_counts["events"],
                 saved_counts["npcs"],
                 "updated" if saved_counts["state"] else "no change",
+                saved_counts.get("anchors", "no change"),
                 f"+{saved_counts['time']:.1f}d" if saved_counts.get("time") else "no change",
                 repr(saved_counts.get("title", "—")),
                 saved_counts.get("plan", "no change"),
@@ -1059,6 +1173,9 @@ def _build_augmented_message(
         parts.append(branch_lore)
 
     if not is_blank:
+        sticky_events = app_module.format_sticky_events(story_id, branch_id, limit=4)
+        if sticky_events:
+            parts.append(sticky_events)
         events = app_module.search_relevant_events(story_id, user_text, branch_id, limit=3)
         if events:
             parts.append(events)

--- a/story_core/state_updates.py
+++ b/story_core/state_updates.py
@@ -5,7 +5,12 @@ import logging
 
 from story_core.character_state import _load_character_schema, _load_character_state
 from story_core.dungeon_system import reconcile_dungeon_entry, reconcile_dungeon_exit, validate_dungeon_progression
-from story_core.event_db import get_active_events, insert_event, update_event_status
+from story_core.event_db import (
+    get_active_events,
+    insert_event,
+    update_event_status,
+    update_event_sticky_priority,
+)
 from story_core.npc_helpers import _sync_state_db_from_state
 from story_core.story_io import _save_json, _story_character_state_path
 from story_core.tag_extraction import _NORMALIZE_DASHES_RE, _NORMALIZE_DOTS_RE, _extract_item_base_name
@@ -80,6 +85,42 @@ def _normalize_event_status(raw_status: object) -> str | None:
     return None
 
 
+def _parse_sticky_flag(raw_flag: object) -> bool | None:
+    if raw_flag is None:
+        return None
+    if isinstance(raw_flag, bool):
+        return raw_flag
+    if isinstance(raw_flag, (int, float)):
+        return raw_flag != 0
+    if isinstance(raw_flag, str):
+        value = raw_flag.strip().lower()
+        if value in {"", "none", "null"}:
+            return None
+        if value in {"1", "true", "yes", "y", "on"}:
+            return True
+        if value in {"0", "false", "no", "n", "off"}:
+            return False
+    return bool(raw_flag)
+
+
+def _normalize_event_sticky_priority(
+    raw_priority: object,
+    raw_sticky: object | None = None,
+    *,
+    default: int | None = None,
+) -> int | None:
+    if raw_priority is None:
+        sticky_flag = _parse_sticky_flag(raw_sticky)
+        if sticky_flag is None:
+            return default
+        raw_priority = 1 if sticky_flag else 0
+    try:
+        priority = int(raw_priority)
+    except (TypeError, ValueError):
+        return default
+    return max(0, min(3, priority))
+
+
 def _build_active_events_hint(story_id: str, branch_id: str, limit: int = 40) -> str:
     rows = get_active_events(story_id, branch_id, limit=limit)
     if not rows:
@@ -114,7 +155,14 @@ def _apply_event_ops(
             continue
         event_id = meta.get("id")
         if isinstance(event_id, int):
-            id_map[event_id] = {"title": title, "status": meta.get("status", "")}
+            id_map[event_id] = {
+                "title": title,
+                "status": meta.get("status", ""),
+                "sticky_priority": _normalize_event_sticky_priority(
+                    meta.get("sticky_priority"),
+                    default=0,
+                ) or 0,
+            }
 
     for op in event_ops.get("update", []) if isinstance(event_ops.get("update"), list) else []:
         if not isinstance(op, dict):
@@ -125,17 +173,36 @@ def _apply_event_ops(
         if not isinstance(raw_id, int):
             continue
         new_status = _normalize_event_status(op.get("status"))
-        if not new_status:
+        new_sticky_priority = _normalize_event_sticky_priority(
+            op.get("sticky_priority"),
+            op.get("sticky"),
+            default=None,
+        )
+        if not new_status and new_sticky_priority is None:
             continue
         current = id_map.get(raw_id)
         if not current:
             continue
         old_status = _normalize_event_status(current.get("status")) or str(current.get("status", "")).strip()
-        if _EVENT_STATUS_ORDER.get(new_status, -1) > _EVENT_STATUS_ORDER.get(old_status, -1):
+        old_sticky_priority = _normalize_event_sticky_priority(
+            current.get("sticky_priority"),
+            default=0,
+        ) or 0
+        if new_status and _EVENT_STATUS_ORDER.get(new_status, -1) > _EVENT_STATUS_ORDER.get(old_status, -1):
             update_event_status(story_id, raw_id, new_status)
             title = current["title"]
             existing_title_map[title]["status"] = new_status
             id_map[raw_id]["status"] = new_status
+            writes += 1
+        if (
+            new_sticky_priority is not None
+            and new_sticky_priority != old_sticky_priority
+            and (new_sticky_priority == 0 or new_sticky_priority > old_sticky_priority)
+        ):
+            update_event_sticky_priority(story_id, raw_id, new_sticky_priority)
+            title = current["title"]
+            existing_title_map.setdefault(title, {})["sticky_priority"] = new_sticky_priority
+            id_map[raw_id]["sticky_priority"] = new_sticky_priority
             writes += 1
 
     for op in event_ops.get("create", []) if isinstance(event_ops.get("create"), list) else []:
@@ -145,17 +212,42 @@ def _apply_event_ops(
         if not title:
             continue
         new_status = _normalize_event_status(op.get("status")) or "planted"
+        new_sticky_priority = _normalize_event_sticky_priority(
+            op.get("sticky_priority"),
+            op.get("sticky"),
+            default=0,
+        ) or 0
         if title in existing_titles:
             existing = existing_title_map.get(title, {})
             event_id = existing.get("id")
             old_status = _normalize_event_status(existing.get("status")) or str(existing.get("status", "")).strip()
+            old_sticky_priority = _normalize_event_sticky_priority(
+                existing.get("sticky_priority"),
+                default=0,
+            ) or 0
             if (
                 isinstance(event_id, int)
                 and _EVENT_STATUS_ORDER.get(new_status, -1) > _EVENT_STATUS_ORDER.get(old_status, -1)
             ):
                 update_event_status(story_id, event_id, new_status)
                 existing_title_map[title]["status"] = new_status
-                id_map[event_id] = {"title": title, "status": new_status}
+                id_map[event_id] = {
+                    "title": title,
+                    "status": new_status,
+                    "sticky_priority": old_sticky_priority,
+                }
+                writes += 1
+            if isinstance(event_id, int) and new_sticky_priority > old_sticky_priority:
+                update_event_sticky_priority(story_id, event_id, new_sticky_priority)
+                existing_title_map[title]["sticky_priority"] = new_sticky_priority
+                id_map.setdefault(
+                    event_id,
+                    {
+                        "title": title,
+                        "status": existing.get("status", ""),
+                        "sticky_priority": old_sticky_priority,
+                    },
+                )["sticky_priority"] = new_sticky_priority
                 writes += 1
             continue
 
@@ -166,11 +258,20 @@ def _apply_event_ops(
             "message_index": msg_index,
             "status": new_status,
             "tags": op.get("tags", ""),
+            "sticky_priority": new_sticky_priority,
         }
         new_id = insert_event(story_id, payload, branch_id)
         existing_titles.add(title)
-        existing_title_map[title] = {"id": new_id, "status": new_status}
-        id_map[new_id] = {"title": title, "status": new_status}
+        existing_title_map[title] = {
+            "id": new_id,
+            "status": new_status,
+            "sticky_priority": new_sticky_priority,
+        }
+        id_map[new_id] = {
+            "title": title,
+            "status": new_status,
+            "sticky_priority": new_sticky_priority,
+        }
         writes += 1
 
     return writes

--- a/story_core/tag_extraction.py
+++ b/story_core/tag_extraction.py
@@ -15,7 +15,7 @@ _DEBUG_DIRECTIVE_RE = re.compile(r"<!--DEBUG_DIRECTIVE\s*(.*?)\s*DEBUG_DIRECTIVE
 _DEBUG_ACTION_TYPES = {"state_patch", "npc_upsert", "npc_delete", "world_day_set", "dungeon_patch"}
 
 _CONTEXT_ECHO_RE = re.compile(
-    r"\[(?:命運走向|命運判定|命運骰結果|相關世界設定|相關事件追蹤|NPC 近期動態|GM 敘事計劃（僅供 GM 內部參考，勿透露給玩家）|Debug 修正指令（僅供 GM 內部參考，勿透露給玩家）)\].*?(?=\n---\n|\n\n[^\[\n]|\Z)",
+    r"\[(?:長期關鍵事件|命運走向|命運判定|命運骰結果|相關世界設定|相關事件追蹤|NPC 近期動態|GM 敘事計劃（僅供 GM 內部參考，勿透露給玩家）|Debug 修正指令（僅供 GM 內部參考，勿透露給玩家）)\].*?(?=\n---\n|\n\n[^\[\n]|\Z)",
     re.DOTALL,
 )
 

--- a/tests/test_context_injection.py
+++ b/tests/test_context_injection.py
@@ -142,6 +142,28 @@ class TestBuildAugmentedMessage:
         assert "---\n原始訊息" in text
 
     @mock.patch("app.search_relevant_lore", return_value="")
+    @mock.patch("app.format_sticky_events", return_value="[長期關鍵事件]\n- 神王追索")
+    @mock.patch("app.search_relevant_events", return_value="[相關事件追蹤]\n- 水靈珠線索")
+    @mock.patch("app.get_recent_activities", return_value="")
+    @mock.patch("app.is_gm_command", return_value=False)
+    @mock.patch("app.get_fate_mode", return_value=False)
+    def test_sticky_events_injected_before_query_events(
+        self,
+        _mock_fate,
+        _mock_gm,
+        _mock_act,
+        _mock_evt,
+        _mock_sticky,
+        _mock_lore,
+        story_id,
+        setup_story,
+    ):
+        text, _ = app_module._build_augmented_message(story_id, "main", "我要找水靈珠", {"current_phase": "副本中"})
+        assert "[長期關鍵事件]" in text
+        assert "[相關事件追蹤]" in text
+        assert text.index("[長期關鍵事件]") < text.index("[相關事件追蹤]")
+
+    @mock.patch("app.search_relevant_lore", return_value="")
     @mock.patch("app.search_relevant_events", return_value="")
     @mock.patch("app.get_recent_activities", return_value="")
     @mock.patch("app.is_gm_command", return_value=True)
@@ -256,6 +278,43 @@ class TestBuildAugmentedMessage:
             [{"name": "阿豪", "role": "隊友", "lifecycle_status": "active"}],
         )
         assert "安德斯" in text
+
+
+class TestCriticalFactsAnchors:
+    def test_critical_facts_include_story_anchors(self, story_id, setup_story):
+        branch_dir = setup_story / "branches" / "main"
+        state_path = branch_dir / "character_state.json"
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        state["story_anchors"] = [
+            "長期主線：回歸現實",
+            "核心隊伍關係：與小琳有深層心靈同調",
+        ]
+        state_path.write_text(json.dumps(state, ensure_ascii=False), encoding="utf-8")
+
+        loaded_state = app_module._load_character_state(story_id, "main")
+        text = app_module._build_critical_facts(story_id, "main", loaded_state, [])
+        assert "### 長期記憶" in text
+        assert "長期主線：回歸現實" in text
+
+    def test_load_character_state_self_heals_story_anchors(self, story_id, setup_story):
+        branch_dir = setup_story / "branches" / "main"
+        state_path = branch_dir / "character_state.json"
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        state.pop("story_anchors", None)
+        state_path.write_text(json.dumps(state, ensure_ascii=False), encoding="utf-8")
+
+        loaded_state = app_module._load_character_state(story_id, "main")
+        persisted = json.loads(state_path.read_text(encoding="utf-8"))
+        assert loaded_state["story_anchors"] == []
+        assert persisted["story_anchors"] == []
+
+    def test_story_anchors_capped_at_ten(self, story_id, setup_story):
+        state = {
+            "current_phase": "副本中",
+            "story_anchors": [f"錨點{i}" for i in range(12)],
+        }
+        text = app_module._build_critical_facts(story_id, "main", state, [])
+        assert text.count("- 錨點") == 10
 
     @mock.patch("app.search_relevant_lore", return_value="")
     @mock.patch("app.search_relevant_events", return_value="")

--- a/tests/test_event_db.py
+++ b/tests/test_event_db.py
@@ -117,6 +117,15 @@ class TestInsertEvent:
         fetched = event_db.get_event_by_id(story_id, eid)
         assert fetched["tags"] == "重要,劇情"
 
+    def test_insert_with_sticky_priority(self, story_id):
+        eid = event_db.insert_event(
+            story_id,
+            {"event_type": "伏筆", "title": "長期壓力", "description": "d", "sticky_priority": 2},
+            "main",
+        )
+        fetched = event_db.get_event_by_id(story_id, eid)
+        assert fetched["sticky_priority"] == 2
+
 
 # ===================================================================
 # get_events
@@ -229,6 +238,7 @@ class TestSearchRelevantEvents:
         assert "[相關事件追蹤]" in text
         assert "神秘組織的暗示" in text
         assert "已埋" in text  # status=planted
+        assert "[長期關鍵事件]" not in text
 
     def test_empty_result(self, story_id):
         text = event_db.search_relevant_events(story_id, "不存在", "main")
@@ -244,6 +254,51 @@ class TestSearchRelevantEvents:
         text = event_db.search_relevant_events(story_id, "長描述", "main")
         # Description should be truncated at 200 chars
         assert len(text) < 500
+
+
+class TestStickyEvents:
+    def test_get_sticky_events_returns_only_positive_priority(self, story_id):
+        event_db.insert_event(
+            story_id,
+            {"event_type": "伏筆", "title": "一般事件", "description": "d", "sticky_priority": 0},
+            "main",
+        )
+        event_db.insert_event(
+            story_id,
+            {"event_type": "伏筆", "title": "長期威脅", "description": "d", "sticky_priority": 2},
+            "main",
+        )
+        results = event_db.get_sticky_events(story_id, "main")
+        assert [row["title"] for row in results] == ["長期威脅"]
+
+    def test_get_sticky_events_orders_by_priority_then_newest(self, story_id):
+        event_db.insert_event(
+            story_id,
+            {"event_type": "伏筆", "title": "優先度1", "description": "d", "sticky_priority": 1},
+            "main",
+        )
+        event_db.insert_event(
+            story_id,
+            {"event_type": "伏筆", "title": "優先度3舊", "description": "d", "sticky_priority": 3},
+            "main",
+        )
+        event_db.insert_event(
+            story_id,
+            {"event_type": "伏筆", "title": "優先度3新", "description": "d", "sticky_priority": 3},
+            "main",
+        )
+        results = event_db.get_sticky_events(story_id, "main", limit=3)
+        assert [row["title"] for row in results] == ["優先度3新", "優先度3舊", "優先度1"]
+
+    def test_format_sticky_events_heading(self, story_id):
+        event_db.insert_event(
+            story_id,
+            {"event_type": "伏筆", "title": "神王追索", "description": "仍在追查", "sticky_priority": 2},
+            "main",
+        )
+        text = event_db.format_sticky_events(story_id, "main")
+        assert "[長期關鍵事件]" in text
+        assert "神王追索" in text
 
 
 # ===================================================================
@@ -323,6 +378,16 @@ class TestCopyEventsForFork:
         titles = {e["title"] for e in copied}
         assert titles == {"事件一", "事件二"}
 
+    def test_preserves_sticky_priority(self, story_id):
+        event_db.insert_event(
+            story_id,
+            {"event_type": "伏筆", "title": "神王追索", "description": "d", "sticky_priority": 3},
+            "main",
+        )
+        event_db.copy_events_for_fork(story_id, "main", "branch_a", None)
+        copied = event_db.get_events(story_id, branch_id="branch_a", limit=20)
+        assert copied[0]["sticky_priority"] == 3
+
 
 class TestMergeEventsInto:
     def test_inserts_new_titles_into_destination(self, story_id):
@@ -352,6 +417,23 @@ class TestMergeEventsInto:
         match = [e for e in merged if e["title"] == "同標題事件"]
         assert len(match) == 1
         assert match[0]["status"] == "resolved"
+
+    def test_preserves_sticky_priority_on_update(self, story_id):
+        event_db.insert_event(
+            story_id,
+            {"event_type": "伏筆", "title": "長期威脅", "description": "d", "status": "planted", "sticky_priority": 0},
+            "main",
+        )
+        event_db.insert_event(
+            story_id,
+            {"event_type": "伏筆", "title": "長期威脅", "description": "d", "status": "triggered", "sticky_priority": 2},
+            "child",
+        )
+        event_db.merge_events_into(story_id, "child", "main")
+        merged = event_db.get_events(story_id, branch_id="main", limit=20)
+        match = [e for e in merged if e["title"] == "長期威脅"]
+        assert len(match) == 1
+        assert match[0]["sticky_priority"] == 2
 
 
 class TestDeleteEventsForBranch:

--- a/tests/test_extract_tags_async.py
+++ b/tests/test_extract_tags_async.py
@@ -465,6 +465,73 @@ class TestAsyncEventOps:
         assert len(matching) == 1
         assert matching[0]["status"] == "triggered"
 
+    @mock.patch("story_core.llm_bridge.call_oneshot")
+    def test_event_ops_update_by_id_can_set_sticky_priority(self, mock_llm, story_id, setup_story):
+        event_id = event_db.insert_event(story_id, {
+            "event_type": "伏筆", "title": "神王追索", "description": "d", "status": "planted"
+        }, "main")
+        mock_llm.return_value = json.dumps({
+            "event_ops": {
+                "update": [{"id": event_id, "sticky": True}],
+            },
+        })
+
+        app_module._extract_tags_async(story_id, "main", "GM回覆文字測試" * 50, msg_index=11)
+
+        updated = event_db.get_event_by_id(story_id, event_id)
+        assert updated["sticky_priority"] == 1
+
+    @mock.patch("story_core.llm_bridge.call_oneshot")
+    def test_legacy_events_dedup_can_raise_sticky_priority(self, mock_llm, story_id, setup_story):
+        event_db.insert_event(story_id, {
+            "event_type": "伏筆", "title": "白鴉邀約", "description": "old", "status": "planted", "sticky_priority": 0
+        }, "main")
+        mock_llm.return_value = json.dumps({
+            "events": [
+                {
+                    "event_type": "伏筆",
+                    "title": "白鴉邀約",
+                    "description": "new",
+                    "status": "triggered",
+                    "sticky": True,
+                    "tags": "",
+                },
+            ],
+        })
+
+        app_module._extract_tags_async(story_id, "main", "GM回覆文字測試" * 50, msg_index=12)
+
+        events = event_db.get_events(story_id, branch_id="main", limit=20)
+        matching = [e for e in events if e["title"] == "白鴉邀約"]
+        assert len(matching) == 1
+        assert matching[0]["status"] == "triggered"
+        assert matching[0]["sticky_priority"] == 1
+
+
+class TestAsyncStoryAnchors:
+    @mock.patch("story_core.llm_bridge.call_oneshot")
+    def test_story_anchor_ops_add_update_remove(self, mock_llm, story_id, setup_story):
+        state_path = setup_story / "branches" / "main" / "character_state.json"
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        state["story_anchors"] = ["長期主線：舊目標", "待移除錨點"]
+        state_path.write_text(json.dumps(state, ensure_ascii=False), encoding="utf-8")
+
+        mock_llm.return_value = json.dumps({
+            "story_anchors": {
+                "add": ["核心關係：與小琳深層同調"],
+                "update": [{"old": "長期主線：舊目標", "new": "長期主線：回歸現實"}],
+                "remove": ["待移除錨點"],
+            },
+        })
+
+        app_module._extract_tags_async(story_id, "main", "GM回覆文字測試" * 50, msg_index=13)
+
+        updated = json.loads(state_path.read_text(encoding="utf-8"))
+        assert updated["story_anchors"] == [
+            "長期主線：回歸現實",
+            "核心關係：與小琳深層同調",
+        ]
+
 
 # ===================================================================
 # Lore extraction

--- a/tests/test_tag_extraction.py
+++ b/tests/test_tag_extraction.py
@@ -10,6 +10,7 @@ import re
 import pytest
 
 from app import (
+    _CONTEXT_ECHO_RE,
     _extract_state_tag,
     _extract_lore_tag,
     _extract_npc_tag,
@@ -324,3 +325,13 @@ class TestRegexPatterns:
     def test_dotall_multiline(self):
         text = '<!--STATE {\n"a": 1\n} STATE-->'
         assert _STATE_RE.search(text) is not None
+
+    def test_context_echo_re_strips_sticky_events_block(self):
+        text = (
+            "[長期關鍵事件]\n"
+            "- [伏筆] 神王追索（已觸發）：仍在追索\n"
+            "---\n"
+            "玩家真正看到的回覆"
+        )
+        clean = _CONTEXT_ECHO_RE.sub("", text).strip()
+        assert clean == "---\n玩家真正看到的回覆"


### PR DESCRIPTION
## Summary
- add `story_anchors` as an always-on identity memory layer in `critical_facts`
- add `sticky_priority` events with separate `[長期關鍵事件]` injection and extraction support
- add `backfill_story_memory.py` plus docs and test coverage for the new memory layers

## Testing
- `pytest tests/test_event_db.py -q`
- `pytest tests/test_context_injection.py -q`
- `pytest tests/test_extract_tags_async.py -q`
- `pytest tests/test_state_update.py -q`
- `pytest tests/test_api_routes.py -q`
- `python3 -m py_compile story_core/character_state.py story_core/event_db.py story_core/state_updates.py story_core/gm_pipeline.py scripts/backfill/backfill_story_memory.py`

## Notes
- did not run prod backfill dry-run or manual E2E against `story-prod` in this branch