### PR TITLE
Add read-only Codex GM provider

### DIFF
--- a/doc/api_reference.md
+++ b/doc/api_reference.md
@@ -155,7 +155,7 @@
 | Method | Path | 說明 | 主要參數 |
 |---|---|---|---|
 | GET | `/api/config` | 讀 LLM 設定（已脫敏，不回傳 key） | - |
-| POST | `/api/config` | 更新 provider/model | body: `provider`, `gemini.model`, `claude_cli.model` |
+| POST | `/api/config` | 更新 provider/model | body: `provider`, `gemini.model`, `claude_cli.model`, `codex_agent.model` |
 | GET | `/api/cheats/dice` | 讀骰子 cheat 狀態 | `branch_id` |
 | POST | `/api/cheats/dice` | 設定 always_success | body: `branch_id`, `always_success` |
 | GET | `/api/cheats/fate` | 讀 fate mode | `branch_id` |
@@ -184,3 +184,11 @@
 注意：
 
 - 目前建議在 dungeon API 明確傳 `branch_id`，避免走 fallback path。
+
+`/api/config` 回傳補充：
+- `provider` 目前可能值：`gemini` / `claude_cli` / `codex_agent`
+- 回傳結構固定包含：
+  - `gemini.model`
+  - `claude_cli.model`
+  - `codex_agent.model`
+- `codex_agent` 是 read-only provider。前端看起來只是另一個模型供應商選項；後端仍走同一套 `/api/send*`、GM parser、snapshot 與 async extractor 流程。

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -8,7 +8,7 @@
 Browser (static/app.js, templates/index.html)
   -> Flask app (app.py)
       -> LLM bridge (story_core/llm_bridge.py)
-          -> story_core/gemini_bridge.py 或 story_core/claude_bridge.py
+          -> story_core/gemini_bridge.py / story_core/claude_bridge.py / story_core/codex_bridge.py
       -> Lore / Event / Usage / State SQLite
       -> JSON runtime files (messages/state/npcs/branch tree/saves...)
       -> Background threads (tag extraction, compaction, NPC evolution, state cleanup, image gen)
@@ -31,6 +31,10 @@ Browser (static/app.js, templates/index.html)
   - 內建 retention prune（按日期資料夾清理）
 - `story_core/gemini_bridge.py` / `story_core/claude_bridge.py`
   - Gemini API 或 Claude CLI 的實際呼叫
+- `story_core/codex_bridge.py`
+  - Codex CLI 的 read-only provider
+  - 以臨時工作區暴露當前 branch timeline / state / lore / recap / plan
+  - 仍走既有 GM parser / snapshot / async extractor pipeline
 - `story_core/lore_db.py` / `story_core/event_db.py` / `story_core/usage_db.py`
   - 各自獨立 SQLite
 - `story_core/state_db.py`

--- a/doc/development.md
+++ b/doc/development.md
@@ -7,6 +7,7 @@
 - Python 3.11+（WSL2 文件示例使用 3.12）
 - `pip`
 - 若使用 Claude provider：`@anthropic-ai/claude-code` CLI
+- 若使用 Codex provider：`codex` CLI
 
 ### 安裝
 
@@ -20,9 +21,14 @@ pip install -r requirements.txt
 
 建立或修改 `llm_config.json`（含金鑰，不應提交）：
 
-- `provider`: `gemini` 或 `claude_cli`
+- `provider`: `gemini`、`claude_cli` 或 `codex_agent`
 - `gemini.api_keys`: 可放多把 key（系統會做 fallback/cooldown）
-- `gemini.model` / `claude_cli.model`
+- `gemini.model` / `claude_cli.model` / `codex_agent.model`
+
+`codex_agent` 備註：
+- 目前是 read-only provider，只會在臨時工作區內讀取 branch/lore/context 檔案。
+- 它不會直接寫 runtime JSON；最終仍由既有 Flask route + `gm_pipeline` 落盤。
+- 串流模式目前是 bridge 端相容層：Codex 先完成整段 GM 回覆，再切成 SSE chunk 回前端。
 
 ## 2) 本機啟動流程
 

--- a/doc/development.md
+++ b/doc/development.md
@@ -28,7 +28,7 @@ pip install -r requirements.txt
 `codex_agent` 備註：
 - 目前是 read-only provider，只會在臨時工作區內讀取 branch/lore/context 檔案。
 - 它不會直接寫 runtime JSON；最終仍由既有 Flask route + `gm_pipeline` 落盤。
-- 串流模式目前是 bridge 端相容層：Codex 先完成整段 GM 回覆，再切成 SSE chunk 回前端。
+- 串流模式走 `codex exec --json`；bridge 會在回覆生成期間維持 SSE 活性，並在收到 agent message 時盡快往前端轉發正文。
 
 ## 2) 本機啟動流程
 

--- a/doc/readme.md
+++ b/doc/readme.md
@@ -8,7 +8,7 @@
 - 角色狀態追蹤（含 inventory/systems/relationships）
 - 世界觀知識庫（lore）與事件追蹤（events）
 - 命運骰、GM cheats、存檔、副本進度系統
-- 多 LLM provider（Gemini / Claude CLI）與串流回應
+- 多 LLM provider（Gemini / Claude CLI / Codex Agent）與串流回應
 
 目前主要的 Python 內部模組已整理到 `story_core/`；entrypoints 仍維持在 repo root（例如 `app.py`、`auto_play.py`）。
 
@@ -33,9 +33,16 @@ pip install -r requirements.txt
   },
   "claude_cli": {
     "model": "claude-opus-4-6"
+  },
+  "codex_agent": {
+    "model": "gpt-5.4"
   }
 }
 ```
+
+說明：
+- `codex_agent` 是 read-only GM provider。後端會為每回合建立臨時工作區，只暴露當前 branch 與 lore 相關檔案給 Codex 讀取，不會讓它直接改 runtime data。
+- UI 仍維持同一套 `/api/send*` / parser / state pipeline；Codex 只是新的可選 provider，不會替換既有 Gemini / Claude 路徑。
 
 3. 啟動服務
 

--- a/routes/branch_routes.py
+++ b/routes/branch_routes.py
@@ -636,7 +636,12 @@ def api_branches_edit():
     t0 = time.time()
     try:
         gm_response, _ = app_module.call_claude_gm(
-            augmented_edit, system_prompt, recent, session_id=None
+            augmented_edit,
+            system_prompt,
+            recent,
+            session_id=None,
+            story_id=story_id,
+            branch_id=branch_id,
         )
     except Exception as exc:
         log.info("/api/branches/edit EXCEPTION %s", exc)
@@ -839,7 +844,12 @@ def api_branches_edit_stream():
             yield app_module._sse_event({"type": "dice", "dice": dice_result})
         try:
             for event_type, payload in app_module.call_claude_gm_stream(
-                augmented_edit, system_prompt, recent, session_id=None
+                augmented_edit,
+                system_prompt,
+                recent,
+                session_id=None,
+                story_id=story_id,
+                branch_id=branch_id,
             ):
                 if event_type == "text":
                     yield app_module._sse_event({"type": "text", "chunk": payload})
@@ -1046,7 +1056,12 @@ def api_branches_regenerate():
     t0 = time.time()
     try:
         gm_response, _ = app_module.call_claude_gm(
-            augmented_regen, system_prompt, recent, session_id=None
+            augmented_regen,
+            system_prompt,
+            recent,
+            session_id=None,
+            story_id=story_id,
+            branch_id=branch_id,
         )
     except Exception as exc:
         log.info("/api/branches/regenerate EXCEPTION %s", exc)
@@ -1227,7 +1242,12 @@ def api_branches_regenerate_stream():
             yield app_module._sse_event({"type": "dice", "dice": dice_result})
         try:
             for event_type, payload in app_module.call_claude_gm_stream(
-                augmented_regen, system_prompt, recent, session_id=None
+                augmented_regen,
+                system_prompt,
+                recent,
+                session_id=None,
+                story_id=story_id,
+                branch_id=branch_id,
             ):
                 if event_type == "text":
                     yield app_module._sse_event({"type": "text", "chunk": payload})

--- a/routes/core_routes.py
+++ b/routes/core_routes.py
@@ -293,7 +293,12 @@ def api_send():
     )
     t0 = time.time()
     gm_response, _ = app_module.call_claude_gm(
-        augmented_text, system_prompt, recent, session_id=None
+        augmented_text,
+        system_prompt,
+        recent,
+        session_id=None,
+        story_id=story_id,
+        branch_id=branch_id,
     )
     gm_elapsed = time.time() - t0
     log.info("  claude_call: %.1fs", gm_elapsed)
@@ -440,7 +445,12 @@ def api_send_stream():
             yield _sse_event({"type": "dice", "dice": dice_result})
         try:
             for event_type, payload in app_module.call_claude_gm_stream(
-                augmented_text, system_prompt, recent, session_id=None
+                augmented_text,
+                system_prompt,
+                recent,
+                session_id=None,
+                story_id=story_id,
+                branch_id=branch_id,
             ):
                 if event_type == "text":
                     yield _sse_event({"type": "text", "chunk": payload})

--- a/routes/debug_routes.py
+++ b/routes/debug_routes.py
@@ -107,7 +107,12 @@ def api_debug_chat_stream():
         t_start = time.time()
         try:
             for event_type, payload in app_module.call_claude_gm_stream(
-                user_message, debug_system_prompt, prior, session_id=None
+                user_message,
+                debug_system_prompt,
+                prior,
+                session_id=None,
+                story_id=story_id,
+                branch_id=branch_id,
             ):
                 if event_type == "text":
                     yield app_module._sse_event({"type": "text", "chunk": payload})

--- a/routes/lore_routes.py
+++ b/routes/lore_routes.py
@@ -452,6 +452,7 @@ def api_lore_chat_stream():
                 prior,
                 session_id=None,
                 tools=tools,
+                story_id=story_id,
             ):
                 if event_type == "text":
                     yield app_module._sse_event({"type": "text", "chunk": payload})
@@ -527,4 +528,3 @@ def api_lore_apply():
                 app_module.delete_lore_entry(story_id, topic, subcategory)
                 applied.append({"action": "delete", "topic": topic})
     return jsonify({"ok": True, "applied": applied})
-

--- a/routes/misc_routes.py
+++ b/routes/misc_routes.py
@@ -403,6 +403,9 @@ def api_config_get():
             "claude_cli": {
                 "model": cfg.get("claude_cli", {}).get("model", "claude-sonnet-4-5-20250929"),
             },
+            "codex_agent": {
+                "model": cfg.get("codex_agent", {}).get("model", "gpt-5.4"),
+            },
         }
     )
 
@@ -432,6 +435,12 @@ def api_config_set():
             cfg["claude_cli"] = {}
         if "model" in data["claude_cli"]:
             cfg["claude_cli"]["model"] = data["claude_cli"]["model"]
+
+    if "codex_agent" in data and isinstance(data["codex_agent"], dict):
+        if "codex_agent" not in cfg:
+            cfg["codex_agent"] = {}
+        if "model" in data["codex_agent"]:
+            cfg["codex_agent"]["model"] = data["codex_agent"]["model"]
 
     with open(app_module._LLM_CONFIG_PATH, "w", encoding="utf-8") as handle:
         json.dump(cfg, handle, indent=2, ensure_ascii=False)

--- a/static/app.js
+++ b/static/app.js
@@ -3165,13 +3165,29 @@ document.getElementById("dungeon-exit-btn").addEventListener("click", async () =
 
 const GEMINI_MODELS = ["gemini-2.5-pro", "gemini-3-flash-preview"];
 const CLAUDE_MODELS = ["claude-sonnet-4-6", "claude-opus-4-6"];
+const CODEX_MODELS = ["gpt-5.4"];
 const GEMINI_IMAGE_MODELS = [
   "imagen-4.0-ultra-generate-001",
   "gemini-3.1-flash-image-preview",
   "gemini-2.5-flash-image",
 ];
 let serverDefaultImageModel = "";
-const PROVIDER_LABELS = { gemini: "Gemini", claude_cli: "Claude" };
+const PROVIDER_LABELS = { gemini: "Gemini", claude_cli: "Claude", codex_agent: "Codex" };
+const PROVIDER_MODELS = {
+  gemini: GEMINI_MODELS,
+  claude_cli: CLAUDE_MODELS,
+  codex_agent: CODEX_MODELS,
+};
+
+function getModelsForProvider(provider) {
+  return PROVIDER_MODELS[provider] || CLAUDE_MODELS;
+}
+
+function getCurrentProviderModel(cfg, provider) {
+  if (provider === "gemini") return cfg.gemini?.model;
+  if (provider === "codex_agent") return cfg.codex_agent?.model;
+  return cfg.claude_cli?.model;
+}
 
 function getDefaultImageModel() {
   const model = (serverDefaultImageModel || "").trim();
@@ -3201,7 +3217,7 @@ async function loadConfigPanel() {
     // Populate model dropdown based on current provider
     function updateModelDropdown(provider, currentModel) {
       modelSel.innerHTML = "";
-      const models = provider === "gemini" ? GEMINI_MODELS : CLAUDE_MODELS;
+      const models = getModelsForProvider(provider);
       for (const m of models) {
         const opt = document.createElement("option");
         opt.value = m;
@@ -3211,18 +3227,17 @@ async function loadConfigPanel() {
       }
     }
 
-    const currentModel = cfg.provider === "gemini"
-      ? cfg.gemini.model
-      : cfg.claude_cli.model;
+    const currentModel = getCurrentProviderModel(cfg, cfg.provider);
     updateModelDropdown(cfg.provider, currentModel);
 
     // On provider change
     provSel.onchange = async () => {
       const newProv = provSel.value;
-      const models = newProv === "gemini" ? GEMINI_MODELS : CLAUDE_MODELS;
+      const models = getModelsForProvider(newProv);
       updateModelDropdown(newProv, models[0]);
       const update = { provider: newProv };
       if (newProv === "gemini") update.gemini = { model: models[0] };
+      else if (newProv === "codex_agent") update.codex_agent = { model: models[0] };
       else update.claude_cli = { model: models[0] };
       await API.setConfig(update);
     };
@@ -3232,6 +3247,7 @@ async function loadConfigPanel() {
       const prov = provSel.value;
       const update = {};
       if (prov === "gemini") update.gemini = { model: modelSel.value };
+      else if (prov === "codex_agent") update.codex_agent = { model: modelSel.value };
       else update.claude_cli = { model: modelSel.value };
       await API.setConfig(update);
     };
@@ -3604,9 +3620,8 @@ async function loadAddonPanelState() {
       const sel = document.getElementById("addon-model-combined");
       if (sel) {
         sel.innerHTML = "";
-        const currentModel = cfg.provider === "gemini" ? cfg.gemini.model : cfg.claude_cli.model;
-        const providerModels = { gemini: GEMINI_MODELS, claude_cli: CLAUDE_MODELS };
-        for (const [prov, models] of Object.entries(providerModels)) {
+        const currentModel = getCurrentProviderModel(cfg, cfg.provider);
+        for (const [prov, models] of Object.entries(PROVIDER_MODELS)) {
           const group = document.createElement("optgroup");
           group.label = PROVIDER_LABELS[prov] || prov;
           for (const m of models) {
@@ -3623,6 +3638,7 @@ async function loadAddonPanelState() {
           const [newProv, newModel] = sel.value.split("|");
           const update = { provider: newProv };
           if (newProv === "gemini") update.gemini = { model: newModel };
+          else if (newProv === "codex_agent") update.codex_agent = { model: newModel };
           else update.claude_cli = { model: newModel };
           await API.setConfig(update);
           // Sync drawer dropdowns

--- a/story_core/auto_play.py
+++ b/story_core/auto_play.py
@@ -412,7 +412,12 @@ def execute_turn(
     # 5. Call GM (stateless)
     t0_gm = time.time()
     gm_response, _ = call_claude_gm(
-        augmented_text, system_prompt, recent, session_id=None
+        augmented_text,
+        system_prompt,
+        recent,
+        session_id=None,
+        story_id=story_id,
+        branch_id=branch_id,
     )
     _gm_elapsed = time.time() - t0_gm
     usage_db.log_from_bridge(story_id, "gm", _gm_elapsed, branch_id=branch_id)

--- a/story_core/codex_bridge.py
+++ b/story_core/codex_bridge.py
@@ -1,0 +1,318 @@
+"""Bridge to Codex CLI in a read-only, branch-scoped workspace."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+from story_core.branch_tree import get_full_timeline
+from story_core.compaction import load_recap
+from story_core.gm_plan import _load_gm_plan
+from story_core.lore_helpers import _load_branch_lore
+from story_core.story_io import (
+    _dungeon_progress_path,
+    _load_json,
+    _load_tree,
+    _story_character_state_path,
+    _story_character_schema_path,
+    _story_design_dir,
+    _story_npcs_path,
+)
+
+log = logging.getLogger("rpg")
+
+CODEX_BIN = os.environ.get("CODEX_BIN", "codex")
+CODEX_TIMEOUT = 300
+DEFAULT_CODEX_MODEL = "gpt-5.4"
+_ENV = dict(os.environ)
+
+
+def get_last_usage() -> dict | None:
+    """Codex CLI token usage is not surfaced through this bridge."""
+    return None
+
+
+def _write_text(path: Path, content: str):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _write_json(path: Path, payload):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def _recent_messages_text(recent_messages: list[dict]) -> str:
+    if not recent_messages:
+        return "（無最近訊息）\n"
+    chunks: list[str] = []
+    for msg in recent_messages:
+        role = "玩家" if msg.get("role") == "user" else "GM"
+        idx = msg.get("index")
+        if idx is None:
+            chunks.append(f"【{role}】\n{msg.get('content', '')}")
+        else:
+            chunks.append(f"【{role} #{idx}】\n{msg.get('content', '')}")
+    return "\n\n".join(chunks) + "\n"
+
+
+def _chunk_text(text: str, max_chars: int = 120):
+    remaining = text.strip()
+    while remaining:
+        if len(remaining) <= max_chars:
+            yield remaining
+            return
+        cut = remaining.rfind("\n", 0, max_chars + 1)
+        if cut < max_chars // 2:
+            cut = remaining.rfind("。", 0, max_chars + 1)
+        if cut < max_chars // 2:
+            cut = max_chars
+        chunk = remaining[:cut].strip()
+        if chunk:
+            yield chunk
+        remaining = remaining[cut:].lstrip()
+
+
+def _build_generic_workspace(
+    task_text: str,
+    system_prompt: str | None = None,
+) -> str:
+    workspace = tempfile.mkdtemp(prefix="codex-oneshot-")
+    root = Path(workspace)
+    if system_prompt:
+        _write_text(root / "SYSTEM_PROMPT.txt", system_prompt)
+    _write_text(root / "TASK.md", task_text)
+    return workspace
+
+
+def _build_gm_workspace(
+    *,
+    story_id: str | None,
+    branch_id: str | None,
+    user_message: str,
+    system_prompt: str,
+    recent_messages: list[dict],
+) -> str:
+    workspace = tempfile.mkdtemp(prefix="codex-gm-")
+    root = Path(workspace)
+
+    _write_text(root / "SYSTEM_PROMPT.txt", system_prompt)
+    _write_text(root / "PLAYER_MESSAGE.txt", user_message)
+    _write_json(root / "RECENT_MESSAGES.json", recent_messages)
+    _write_text(root / "RECENT_MESSAGES.txt", _recent_messages_text(recent_messages))
+
+    available_files = [
+        "SYSTEM_PROMPT.txt",
+        "PLAYER_MESSAGE.txt",
+        "RECENT_MESSAGES.json",
+        "RECENT_MESSAGES.txt",
+    ]
+
+    if story_id and branch_id:
+        design_root = Path(_story_design_dir(story_id))
+        tree = _load_tree(story_id)
+        branch_meta = tree.get("branches", {}).get(branch_id, {})
+        timeline = get_full_timeline(story_id, branch_id)
+        recap = load_recap(story_id, branch_id)
+        gm_plan = _load_gm_plan(story_id, branch_id)
+        branch_lore = _load_branch_lore(story_id, branch_id)
+        world_lore = _load_json(str(design_root / "world_lore.json"), [])
+        character_state = _load_json(_story_character_state_path(story_id, branch_id), {})
+        npcs = _load_json(_story_npcs_path(story_id, branch_id), [])
+        dungeon_progress = _load_json(_dungeon_progress_path(story_id, branch_id), {})
+        schema = _load_json(_story_character_schema_path(story_id), {})
+
+        _write_json(root / "BRANCH_META.json", branch_meta)
+        _write_json(root / "FULL_TIMELINE.json", timeline)
+        _write_json(root / "CHARACTER_STATE.json", character_state)
+        _write_json(root / "NPCS.json", npcs)
+        _write_json(root / "CONVERSATION_RECAP.json", recap)
+        _write_json(root / "GM_PLAN.json", gm_plan)
+        _write_json(root / "BRANCH_LORE.json", branch_lore)
+        _write_json(root / "WORLD_LORE.json", world_lore)
+        _write_json(root / "DUNGEON_PROGRESS.json", dungeon_progress)
+        _write_json(root / "CHARACTER_SCHEMA.json", schema)
+
+        available_files.extend(
+            [
+                "BRANCH_META.json",
+                "FULL_TIMELINE.json",
+                "CHARACTER_STATE.json",
+                "NPCS.json",
+                "CONVERSATION_RECAP.json",
+                "GM_PLAN.json",
+                "BRANCH_LORE.json",
+                "WORLD_LORE.json",
+                "DUNGEON_PROGRESS.json",
+                "CHARACTER_SCHEMA.json",
+            ]
+        )
+
+    task = f"""\
+你是文字 RPG 的 GM。你目前在一個只讀工作區中工作。
+
+你必須先閱讀下列檔案：
+- `SYSTEM_PROMPT.txt`
+- `PLAYER_MESSAGE.txt`
+- `RECENT_MESSAGES.json`
+
+如果你需要更長的 continuity、舊副本回憶、NPC 歷史、分支 lore 或副本狀態，才去閱讀其他 JSON 檔。
+工作區可用檔案：
+{os.linesep.join(f"- `{name}`" for name in available_files)}
+
+規則：
+1. 完全遵守 `SYSTEM_PROMPT.txt` 的規則與輸出契約。
+2. 視工作區內容為本回合唯一可讀的遊戲上下文；不要假設工作區外的 branch/runtime 資料。
+3. 只輸出最終 GM 回覆文字本身。
+4. 不要輸出解釋、前言、分析、Markdown code fence，或提到你讀了哪些檔案。
+5. 不要修改任何檔案。
+"""
+    _write_text(root / "TASK.md", task)
+    return workspace
+
+
+def _run_codex_task(*, workspace: str, model: str) -> str:
+    output_path = os.path.join(workspace, "codex_last_message.txt")
+    cmd = [
+        CODEX_BIN,
+        "-a",
+        "never",
+        "exec",
+        "--skip-git-repo-check",
+        "-s",
+        "read-only",
+        "--ephemeral",
+        "-m",
+        model or DEFAULT_CODEX_MODEL,
+        "-o",
+        output_path,
+        "Read TASK.md and follow it exactly.",
+    ]
+
+    log.info("    codex_bridge: calling CLI cwd=%s model=%s", workspace, model or DEFAULT_CODEX_MODEL)
+    t0 = time.time()
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=CODEX_TIMEOUT,
+            cwd=workspace,
+            env=_ENV,
+        )
+    except subprocess.TimeoutExpired:
+        log.info("    codex_bridge: TIMEOUT after %ss", CODEX_TIMEOUT)
+        return "【系統錯誤】Codex 回應逾時，請稍後再試。"
+    except FileNotFoundError:
+        log.info("    codex_bridge: codex CLI not found")
+        return "【系統錯誤】找不到 codex CLI。請確認已安裝 Codex。"
+    except Exception as exc:
+        log.info("    codex_bridge: EXCEPTION %s", exc)
+        return f"【系統錯誤】{exc}"
+
+    elapsed = time.time() - t0
+    response_text = ""
+    if os.path.exists(output_path):
+        try:
+            response_text = Path(output_path).read_text(encoding="utf-8").strip()
+        except Exception:
+            response_text = ""
+
+    if result.returncode == 0 and response_text:
+        log.info("    codex_bridge: OK in %.1fs response_len=%d", elapsed, len(response_text))
+        return response_text
+
+    stderr_text = (result.stderr or "").strip()
+    stdout_text = (result.stdout or "").strip()
+    detail = stderr_text or stdout_text or f"Codex process exited with code {result.returncode}"
+    log.info("    codex_bridge: FAILED in %.1fs rc=%d detail=%s", elapsed, result.returncode, detail[:160])
+    return f"【系統錯誤】Codex 回應失敗：{detail}"
+
+
+def call_codex_gm(
+    user_message: str,
+    system_prompt: str,
+    recent_messages: list[dict],
+    session_id: str | None = None,
+    *,
+    story_id: str | None = None,
+    branch_id: str | None = None,
+    model: str = DEFAULT_CODEX_MODEL,
+) -> tuple[str, str | None]:
+    """Run Codex GM in a read-only branch-scoped workspace."""
+    del session_id
+    workspace = _build_gm_workspace(
+        story_id=story_id,
+        branch_id=branch_id,
+        user_message=user_message,
+        system_prompt=system_prompt,
+        recent_messages=recent_messages,
+    )
+    try:
+        return _run_codex_task(workspace=workspace, model=model), None
+    finally:
+        shutil.rmtree(workspace, ignore_errors=True)
+
+
+def call_codex_gm_stream(
+    user_message: str,
+    system_prompt: str,
+    recent_messages: list[dict],
+    session_id: str | None = None,
+    *,
+    story_id: str | None = None,
+    branch_id: str | None = None,
+    model: str = DEFAULT_CODEX_MODEL,
+    tools: list[dict] | None = None,
+):
+    """Streaming-compatible wrapper for Codex GM.
+
+    Codex CLI is executed once and then chunked into SSE-friendly text deltas.
+    """
+    del tools
+    response, _ = call_codex_gm(
+        user_message,
+        system_prompt,
+        recent_messages,
+        session_id=session_id,
+        story_id=story_id,
+        branch_id=branch_id,
+        model=model,
+    )
+    if response.startswith("【系統錯誤】"):
+        yield ("error", response.replace("【系統錯誤】", "", 1).strip())
+        return
+    for chunk in _chunk_text(response):
+        yield ("text", chunk)
+    yield ("done", {"response": response, "session_id": None, "usage": None})
+
+
+def call_codex_oneshot(
+    prompt: str,
+    *,
+    system_prompt: str | None = None,
+    model: str = DEFAULT_CODEX_MODEL,
+) -> str:
+    """Run a one-shot Codex call in a blank read-only workspace."""
+    task_parts = []
+    if system_prompt:
+        task_parts.append(
+            "你必須遵守 `SYSTEM_PROMPT.txt`。\n"
+            "先閱讀該檔案，再完成使用者要求。"
+        )
+    task_parts.append(
+        "只輸出最終答案本身，不要輸出分析、前言、或 Markdown code fence。\n\n"
+        "## 使用者要求\n"
+        f"{prompt}"
+    )
+    workspace = _build_generic_workspace("\n\n".join(task_parts), system_prompt=system_prompt)
+    try:
+        return _run_codex_task(workspace=workspace, model=model)
+    finally:
+        shutil.rmtree(workspace, ignore_errors=True)

--- a/story_core/codex_bridge.py
+++ b/story_core/codex_bridge.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import select
 import shutil
 import subprocess
 import tempfile
@@ -14,11 +15,14 @@ from pathlib import Path
 from story_core.branch_tree import get_full_timeline
 from story_core.compaction import load_recap
 from story_core.gm_plan import _load_gm_plan
+from story_core.gm_cheats import get_fate_mode
 from story_core.lore_helpers import _load_branch_lore
+from story_core.tag_extraction import _sanitize_recent_messages
 from story_core.story_io import (
     _dungeon_progress_path,
     _load_json,
     _load_tree,
+    _story_dir,
     _story_character_state_path,
     _story_character_schema_path,
     _story_design_dir,
@@ -30,6 +34,7 @@ log = logging.getLogger("rpg")
 CODEX_BIN = os.environ.get("CODEX_BIN", "codex")
 CODEX_TIMEOUT = 300
 DEFAULT_CODEX_MODEL = "gpt-5.4"
+STREAM_KEEPALIVE_S = 8.0
 _ENV = dict(os.environ)
 
 
@@ -118,7 +123,11 @@ def _build_gm_workspace(
         design_root = Path(_story_design_dir(story_id))
         tree = _load_tree(story_id)
         branch_meta = tree.get("branches", {}).get(branch_id, {})
-        timeline = get_full_timeline(story_id, branch_id)
+        strip_fate = not get_fate_mode(_story_dir(story_id), branch_id)
+        timeline = _sanitize_recent_messages(
+            get_full_timeline(story_id, branch_id),
+            strip_fate=strip_fate,
+        )
         recap = load_recap(story_id, branch_id)
         gm_plan = _load_gm_plan(story_id, branch_id)
         branch_lore = _load_branch_lore(story_id, branch_id)
@@ -179,21 +188,7 @@ def _build_gm_workspace(
 
 def _run_codex_task(*, workspace: str, model: str) -> str:
     output_path = os.path.join(workspace, "codex_last_message.txt")
-    cmd = [
-        CODEX_BIN,
-        "-a",
-        "never",
-        "exec",
-        "--skip-git-repo-check",
-        "-s",
-        "read-only",
-        "--ephemeral",
-        "-m",
-        model or DEFAULT_CODEX_MODEL,
-        "-o",
-        output_path,
-        "Read TASK.md and follow it exactly.",
-    ]
+    cmd = _build_codex_cmd(model=model, output_path=output_path)
 
     log.info("    codex_bridge: calling CLI cwd=%s model=%s", workspace, model or DEFAULT_CODEX_MODEL)
     t0 = time.time()
@@ -235,6 +230,27 @@ def _run_codex_task(*, workspace: str, model: str) -> str:
     return f"【系統錯誤】Codex 回應失敗：{detail}"
 
 
+def _build_codex_cmd(*, model: str, output_path: str | None = None, json_stream: bool = False) -> list[str]:
+    cmd = [
+        CODEX_BIN,
+        "-a",
+        "never",
+        "exec",
+        "--skip-git-repo-check",
+        "-s",
+        "read-only",
+        "--ephemeral",
+        "-m",
+        model or DEFAULT_CODEX_MODEL,
+    ]
+    if json_stream:
+        cmd.append("--json")
+    elif output_path:
+        cmd.extend(["-o", output_path])
+    cmd.append("Read TASK.md and follow it exactly.")
+    return cmd
+
+
 def call_codex_gm(
     user_message: str,
     system_prompt: str,
@@ -271,26 +287,136 @@ def call_codex_gm_stream(
     model: str = DEFAULT_CODEX_MODEL,
     tools: list[dict] | None = None,
 ):
-    """Streaming-compatible wrapper for Codex GM.
+    """Streaming wrapper for Codex GM using `codex exec --json`.
 
-    Codex CLI is executed once and then chunked into SSE-friendly text deltas.
+    Codex CLI does not currently provide token-by-token deltas for plain text
+    output, so we forward any completed agent text as soon as it appears and
+    emit empty keepalive chunks while the subprocess is still running.
     """
-    del tools
-    response, _ = call_codex_gm(
-        user_message,
-        system_prompt,
-        recent_messages,
-        session_id=session_id,
+    del tools, session_id
+    workspace = _build_gm_workspace(
         story_id=story_id,
         branch_id=branch_id,
-        model=model,
+        user_message=user_message,
+        system_prompt=system_prompt,
+        recent_messages=recent_messages,
     )
-    if response.startswith("【系統錯誤】"):
-        yield ("error", response.replace("【系統錯誤】", "", 1).strip())
+    try:
+        cmd = _build_codex_cmd(model=model, json_stream=True)
+        log.info("    codex_bridge_stream: calling CLI cwd=%s model=%s", workspace, model or DEFAULT_CODEX_MODEL)
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            bufsize=1,
+            cwd=workspace,
+            env=_ENV,
+        )
+    except FileNotFoundError:
+        shutil.rmtree(workspace, ignore_errors=True)
+        log.info("    codex_bridge_stream: codex CLI not found")
+        yield ("error", "找不到 codex CLI。請確認已安裝 Codex。")
         return
-    for chunk in _chunk_text(response):
-        yield ("text", chunk)
-    yield ("done", {"response": response, "session_id": None, "usage": None})
+    except Exception as exc:
+        shutil.rmtree(workspace, ignore_errors=True)
+        log.info("    codex_bridge_stream: Popen EXCEPTION %s", exc)
+        yield ("error", str(exc))
+        return
+
+    response_text = ""
+    usage = None
+    last_emit_at = time.time()
+
+    try:
+        stdout = proc.stdout
+        assert stdout is not None
+        while True:
+            ready, _, _ = select.select([stdout], [], [], STREAM_KEEPALIVE_S)
+            if not ready:
+                if proc.poll() is not None:
+                    break
+                last_emit_at = time.time()
+                yield ("text", "")
+                continue
+
+            raw_line = stdout.readline()
+            if not raw_line:
+                if proc.poll() is not None:
+                    break
+                continue
+
+            line = raw_line.strip()
+            if not line:
+                continue
+
+            try:
+                data = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+            event_type = data.get("type")
+            if event_type in {"thread.started", "turn.started"}:
+                if time.time() - last_emit_at >= 0.1:
+                    last_emit_at = time.time()
+                    yield ("text", "")
+                continue
+
+            if event_type == "item.completed":
+                item = data.get("item", {}) or {}
+                if item.get("type") == "agent_message":
+                    text = str(item.get("text", "")).strip()
+                    if text and text != response_text:
+                        delta = text[len(response_text):] if text.startswith(response_text) else text
+                        response_text = text
+                        if delta:
+                            last_emit_at = time.time()
+                            yield ("text", delta)
+                continue
+
+            if event_type == "turn.completed":
+                usage = data.get("usage")
+                continue
+
+            if event_type == "error":
+                message = ""
+                err = data.get("error")
+                if isinstance(err, dict):
+                    message = str(err.get("message", "")).strip()
+                if not message:
+                    message = str(data.get("message", "")).strip() or "Codex 執行失敗"
+                yield ("error", message)
+                return
+
+        proc.wait(timeout=10)
+        if proc.returncode != 0 and not response_text:
+            stderr_text = proc.stderr.read().strip() if proc.stderr else ""
+            error_msg = stderr_text or f"Codex process exited with code {proc.returncode}"
+            yield ("error", error_msg)
+            return
+
+        if not response_text:
+            yield ("error", "Codex 回傳空白回應")
+            return
+
+        yield ("done", {"response": response_text, "session_id": None, "usage": usage})
+    except subprocess.TimeoutExpired:
+        try:
+            proc.kill()
+        except Exception:
+            pass
+        yield ("error", "Codex 回應逾時，請稍後再試。")
+    except Exception as exc:
+        try:
+            proc.kill()
+        except Exception:
+            pass
+        if response_text:
+            yield ("done", {"response": response_text, "session_id": None, "usage": usage})
+        else:
+            yield ("error", str(exc))
+    finally:
+        shutil.rmtree(workspace, ignore_errors=True)
 
 
 def call_codex_oneshot(

--- a/story_core/llm_bridge.py
+++ b/story_core/llm_bridge.py
@@ -1,7 +1,7 @@
 """LLM Bridge — dispatches GM calls to the configured provider.
 
 Swap provider by editing llm_config.json (auto-reloads on file change).
-Supported providers: "gemini", "claude_cli"
+Supported providers: "gemini", "claude_cli", "codex_agent"
 """
 
 import json
@@ -70,6 +70,8 @@ def _capture_usage(provider: str, model: str):
     if provider == "gemini":
         from story_core.gemini_bridge import get_last_usage as _gemini_usage
         usage = _gemini_usage()
+    elif provider == "codex_agent":
+        usage = None
     else:
         from story_core.claude_bridge import get_last_usage as _claude_usage
         usage = _claude_usage()
@@ -86,6 +88,9 @@ def call_claude_gm(
     system_prompt: str,
     recent_messages: list[dict],
     session_id: str | None = None,
+    *,
+    story_id: str | None = None,
+    branch_id: str | None = None,
 ) -> tuple[str, str | None]:
     """Unified GM call. Returns (response_text, session_id_or_none)."""
     cfg = _get_config()
@@ -99,6 +104,22 @@ def call_claude_gm(
             user_message, system_prompt, recent_messages,
             gemini_cfg=g, model=model,
             session_id=session_id,
+        )
+        _capture_usage(provider, model)
+        return result
+
+    if provider == "codex_agent":
+        from story_core.codex_bridge import call_codex_gm
+
+        model = cfg.get("codex_agent", {}).get("model", "gpt-5.4")
+        result = call_codex_gm(
+            user_message,
+            system_prompt,
+            recent_messages,
+            session_id=session_id,
+            story_id=story_id,
+            branch_id=branch_id,
+            model=model,
         )
         _capture_usage(provider, model)
         return result
@@ -121,6 +142,9 @@ def call_claude_gm_stream(
     recent_messages: list[dict],
     session_id: str | None = None,
     tools: list[dict] | None = None,
+    *,
+    story_id: str | None = None,
+    branch_id: str | None = None,
 ):
     """Unified streaming GM call. Yields ("text"|"done"|"error", payload).
 
@@ -144,6 +168,24 @@ def call_claude_gm_stream(
                 if usage:
                     payload["usage"] = {**usage, "provider": provider, "model": model}
             yield (event_type, payload)
+        return
+
+    if provider == "codex_agent":
+        if tools:
+            log.debug("llm_bridge: tools=%s ignored for provider %s", tools, provider)
+        from story_core.codex_bridge import call_codex_gm_stream
+
+        model = cfg.get("codex_agent", {}).get("model", "gpt-5.4")
+        yield from call_codex_gm_stream(
+            user_message,
+            system_prompt,
+            recent_messages,
+            session_id=session_id,
+            story_id=story_id,
+            branch_id=branch_id,
+            model=model,
+            tools=tools,
+        )
         return
 
     # Default: Claude CLI (tools not supported)
@@ -177,6 +219,14 @@ def call_oneshot(prompt: str, system_prompt: str | None = None, provider: str | 
             gemini_cfg=g, model=model,
             system_prompt=system_prompt,
         )
+        _capture_usage(provider, model)
+        return result
+
+    if provider == "codex_agent":
+        from story_core.codex_bridge import call_codex_oneshot
+
+        model = cfg.get("codex_agent", {}).get("model", "gpt-5.4")
+        result = call_codex_oneshot(prompt, system_prompt=system_prompt, model=model)
         _capture_usage(provider, model)
         return result
 

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -1275,9 +1275,11 @@ class TestSavesAPI:
 
         captured = {}
 
-        def fake_call_claude_gm(_user_text, system_prompt, _recent, session_id=None):
+        def fake_call_claude_gm(_user_text, system_prompt, _recent, session_id=None, **kwargs):
             captured["system_prompt"] = system_prompt
             assert session_id is None
+            assert kwargs["story_id"] == story_id
+            assert kwargs["branch_id"] == "main"
             return ("GM回覆", None)
 
         monkeypatch.setattr(app_module, "call_claude_gm", fake_call_claude_gm)
@@ -1319,9 +1321,11 @@ class TestSavesAPI:
 
         captured = {}
 
-        def fake_call_claude_gm(_user_text, system_prompt, _recent, session_id=None):
+        def fake_call_claude_gm(_user_text, system_prompt, _recent, session_id=None, **kwargs):
             captured["system_prompt"] = system_prompt
             assert session_id is None
+            assert kwargs["story_id"] == story_id
+            assert kwargs["branch_id"] == "branch_gap"
             return ("GM回覆", None)
 
         monkeypatch.setattr(app_module, "call_claude_gm", fake_call_claude_gm)
@@ -1363,8 +1367,10 @@ class TestSavesAPI:
             encoding="utf-8",
         )
 
-        def fake_call_claude_gm_stream(_user_text, _system_prompt, _recent, session_id=None):
+        def fake_call_claude_gm_stream(_user_text, _system_prompt, _recent, session_id=None, **kwargs):
             assert session_id is None
+            assert kwargs["story_id"] == story_id
+            assert kwargs["branch_id"] == "branch_gap_stream"
             yield ("done", {"response": "GM串流回覆", "usage": None})
 
         monkeypatch.setattr(app_module, "call_claude_gm_stream", fake_call_claude_gm_stream)
@@ -1392,8 +1398,9 @@ class TestSavesAPI:
         preview_status = client.get("/api/status?branch_id=main").get_json()
         assert preview_status["loaded_save_id"] == save["id"]
 
-        def fake_call_claude_gm_stream(_user_text, _system_prompt, _recent, session_id=None):
+        def fake_call_claude_gm_stream(_user_text, _system_prompt, _recent, session_id=None, **kwargs):
             assert session_id is None
+            assert kwargs["branch_id"] == "main"
             yield ("done", {"response": "GM串流回覆", "usage": None})
 
         monkeypatch.setattr(app_module, "call_claude_gm_stream", fake_call_claude_gm_stream)
@@ -1811,9 +1818,23 @@ class TestConfigAPI:
         assert data["ok"] is True
         assert data["provider"] == "gemini"
         assert "version" in data
+        assert data["codex_agent"]["model"] == "gpt-5.4"
         # API keys should NOT be exposed
         raw = json.dumps(data)
         assert "test_key_123" not in raw
+
+    def test_set_config_codex_agent(self, client, setup_story):
+        resp = client.post(
+            "/api/config",
+            json={"provider": "codex_agent", "codex_agent": {"model": "gpt-5.4"}},
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["ok"] is True
+
+        with open(app_module._LLM_CONFIG_PATH, "r", encoding="utf-8") as handle:
+            cfg = json.load(handle)
+        assert cfg["provider"] == "codex_agent"
+        assert cfg["codex_agent"]["model"] == "gpt-5.4"
 
 
 # ===================================================================

--- a/tests/test_codex_bridge.py
+++ b/tests/test_codex_bridge.py
@@ -1,0 +1,165 @@
+import json
+import shutil
+from pathlib import Path
+
+from story_core import codex_bridge
+
+
+def test_build_gm_workspace_sanitizes_full_timeline(monkeypatch):
+    monkeypatch.setattr(
+        codex_bridge,
+        "_load_tree",
+        lambda _story_id: {"branches": {"branch_x": {"id": "branch_x", "name": "測試分支"}}},
+    )
+    monkeypatch.setattr(
+        codex_bridge,
+        "get_full_timeline",
+        lambda _story_id, _branch_id: [
+            {
+                "role": "gm",
+                "index": 1,
+                "content": "前文敘事\n\n**你打算：**\n1. 繼續前進\n2. 先撤退",
+            },
+            {"role": "user", "index": 2, "content": "還記得嗎"},
+        ],
+    )
+    monkeypatch.setattr(codex_bridge, "load_recap", lambda *_args, **_kwargs: {})
+    monkeypatch.setattr(codex_bridge, "_load_gm_plan", lambda *_args, **_kwargs: {})
+    monkeypatch.setattr(codex_bridge, "_load_branch_lore", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(codex_bridge, "get_fate_mode", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(codex_bridge, "_story_dir", lambda _story_id: "/tmp/story")
+    monkeypatch.setattr(codex_bridge, "_story_design_dir", lambda _story_id: "/tmp/design")
+    monkeypatch.setattr(
+        codex_bridge,
+        "_story_character_state_path",
+        lambda _story_id, _branch_id: "/tmp/character_state.json",
+    )
+    monkeypatch.setattr(
+        codex_bridge,
+        "_story_npcs_path",
+        lambda _story_id, _branch_id: "/tmp/npcs.json",
+    )
+    monkeypatch.setattr(
+        codex_bridge,
+        "_dungeon_progress_path",
+        lambda _story_id, _branch_id: "/tmp/dungeon_progress.json",
+    )
+    monkeypatch.setattr(
+        codex_bridge,
+        "_story_character_schema_path",
+        lambda _story_id: "/tmp/character_schema.json",
+    )
+
+    def _fake_load_json(path, default=None):
+        if path.endswith("character_state.json"):
+            return {"current_phase": "主神空間"}
+        if path.endswith("npcs.json"):
+            return []
+        if path.endswith("dungeon_progress.json"):
+            return {}
+        if path.endswith("character_schema.json"):
+            return {"fields": []}
+        if path.endswith("world_lore.json"):
+            return []
+        return default if default is not None else []
+
+    monkeypatch.setattr(codex_bridge, "_load_json", _fake_load_json)
+
+    workspace = codex_bridge._build_gm_workspace(
+        story_id="story_x",
+        branch_id="branch_x",
+        user_message="玩家新行動",
+        system_prompt="system prompt",
+        recent_messages=[{"role": "user", "content": "recent"}],
+    )
+    try:
+        payload = json.loads((Path(workspace) / "FULL_TIMELINE.json").read_text(encoding="utf-8"))
+        assert payload[0]["content"] == "前文敘事"
+        assert "你打算" not in payload[0]["content"]
+    finally:
+        shutil.rmtree(workspace, ignore_errors=True)
+
+
+def test_call_codex_gm_stream_emits_keepalive_then_response(monkeypatch):
+    monkeypatch.setattr(codex_bridge, "_build_gm_workspace", lambda **_kwargs: "/tmp/codex-test")
+    monkeypatch.setattr(codex_bridge.shutil, "rmtree", lambda *_args, **_kwargs: None)
+
+    class _FakeStdout:
+        def __init__(self, lines):
+            self._lines = list(lines)
+
+        def fileno(self):
+            return 1
+
+        def readline(self):
+            if self._lines:
+                return self._lines.pop(0)
+            return ""
+
+        @property
+        def has_pending(self):
+            return bool(self._lines)
+
+    class _FakeStderr:
+        def read(self):
+            return ""
+
+    class _FakeProc:
+        def __init__(self):
+            self.stdout = _FakeStdout(
+                [
+                    '{"type":"thread.started","thread_id":"t1"}\n',
+                    '{"type":"item.completed","item":{"type":"agent_message","text":"最終回覆"}}\n',
+                    '{"type":"turn.completed","usage":{"input_tokens":12,"output_tokens":34}}\n',
+                ]
+            )
+            self.stderr = _FakeStderr()
+            self.returncode = None
+
+        def poll(self):
+            if self.stdout.has_pending:
+                return None
+            return 0
+
+        def wait(self, timeout=None):
+            self.returncode = 0
+            return 0
+
+        def kill(self):
+            self.returncode = -9
+
+    fake_proc = _FakeProc()
+    monkeypatch.setattr(codex_bridge.subprocess, "Popen", lambda *args, **kwargs: fake_proc)
+
+    select_results = iter(
+        [
+            ([], [], []),
+            ([fake_proc.stdout], [], []),
+            ([fake_proc.stdout], [], []),
+            ([fake_proc.stdout], [], []),
+            ([], [], []),
+        ]
+    )
+    monkeypatch.setattr(codex_bridge.select, "select", lambda *args, **kwargs: next(select_results))
+
+    events = list(
+        codex_bridge.call_codex_gm_stream(
+            "玩家新行動",
+            "system prompt",
+            [{"role": "user", "content": "recent"}],
+            story_id="story_x",
+            branch_id="branch_x",
+            model="gpt-5.4",
+        )
+    )
+
+    assert events[0] == ("text", "")
+    assert ("text", "最終回覆") in events
+    assert events[-1] == (
+        "done",
+        {
+            "response": "最終回覆",
+            "session_id": None,
+            "usage": {"input_tokens": 12, "output_tokens": 34},
+        },
+    )

--- a/tests/test_llm_bridge.py
+++ b/tests/test_llm_bridge.py
@@ -1,0 +1,101 @@
+from story_core import llm_bridge
+
+
+def test_call_claude_gm_dispatches_codex_agent(monkeypatch):
+    monkeypatch.setattr(
+        llm_bridge,
+        "_get_config",
+        lambda: {"provider": "codex_agent", "codex_agent": {"model": "gpt-5.4"}},
+    )
+    monkeypatch.setattr(llm_bridge, "_provider_override", None)
+
+    captured = {}
+
+    def _fake_codex_gm(user_message, system_prompt, recent_messages, session_id=None, **kwargs):
+        captured["user_message"] = user_message
+        captured["system_prompt"] = system_prompt
+        captured["recent_messages"] = recent_messages
+        captured["session_id"] = session_id
+        captured.update(kwargs)
+        return ("GM reply", None)
+
+    monkeypatch.setattr("story_core.codex_bridge.call_codex_gm", _fake_codex_gm)
+
+    result = llm_bridge.call_claude_gm(
+        "玩家行動",
+        "system prompt",
+        [{"role": "user", "content": "前文"}],
+        session_id=None,
+        story_id="story_x",
+        branch_id="branch_y",
+    )
+
+    assert result == ("GM reply", None)
+    assert captured["story_id"] == "story_x"
+    assert captured["branch_id"] == "branch_y"
+    assert captured["model"] == "gpt-5.4"
+
+
+def test_call_claude_gm_stream_dispatches_codex_agent(monkeypatch):
+    monkeypatch.setattr(
+        llm_bridge,
+        "_get_config",
+        lambda: {"provider": "codex_agent", "codex_agent": {"model": "gpt-5.4"}},
+    )
+    monkeypatch.setattr(llm_bridge, "_provider_override", None)
+
+    captured = {}
+
+    def _fake_codex_stream(user_message, system_prompt, recent_messages, session_id=None, **kwargs):
+        captured["user_message"] = user_message
+        captured["system_prompt"] = system_prompt
+        captured["recent_messages"] = recent_messages
+        captured["session_id"] = session_id
+        captured.update(kwargs)
+        yield ("text", "片段")
+        yield ("done", {"response": "完整回應", "session_id": None, "usage": None})
+
+    monkeypatch.setattr("story_core.codex_bridge.call_codex_gm_stream", _fake_codex_stream)
+
+    events = list(
+        llm_bridge.call_claude_gm_stream(
+            "玩家行動",
+            "system prompt",
+            [{"role": "user", "content": "前文"}],
+            session_id=None,
+            story_id="story_x",
+            branch_id="branch_y",
+        )
+    )
+
+    assert events[0] == ("text", "片段")
+    assert events[-1][0] == "done"
+    assert captured["story_id"] == "story_x"
+    assert captured["branch_id"] == "branch_y"
+    assert captured["model"] == "gpt-5.4"
+
+
+def test_call_oneshot_dispatches_codex_agent(monkeypatch):
+    monkeypatch.setattr(
+        llm_bridge,
+        "_get_config",
+        lambda: {"provider": "codex_agent", "codex_agent": {"model": "gpt-5.4"}},
+    )
+    monkeypatch.setattr(llm_bridge, "_provider_override", None)
+
+    captured = {}
+
+    def _fake_codex_oneshot(prompt, *, system_prompt=None, model=""):
+        captured["prompt"] = prompt
+        captured["system_prompt"] = system_prompt
+        captured["model"] = model
+        return "{\"ok\": true}"
+
+    monkeypatch.setattr("story_core.codex_bridge.call_codex_oneshot", _fake_codex_oneshot)
+
+    result = llm_bridge.call_oneshot("請輸出 JSON", system_prompt="你是抽取器")
+
+    assert result == "{\"ok\": true}"
+    assert captured["prompt"] == "請輸出 JSON"
+    assert captured["system_prompt"] == "你是抽取器"
+    assert captured["model"] == "gpt-5.4"


### PR DESCRIPTION
## Summary
- add an optional `codex_agent` LLM provider backed by a read-only Codex CLI workspace
- expose Codex in config API and frontend provider/model selectors without changing existing Gemini/Claude behavior
- sanitize long-history context before handing it to Codex and improve Codex SSE behavior with `codex exec --json` keepalive support

## Testing
- pytest /Users/eddylai/story/tests/test_codex_bridge.py /Users/eddylai/story/tests/test_llm_bridge.py /Users/eddylai/story/tests/test_api_routes.py
- pytest /Users/eddylai/story/tests/test_state_update.py /Users/eddylai/story/tests/test_extract_tags_async.py