### PR TITLE
Fix regenerate retry for missing GM replies

### DIFF
--- a/doc/api_reference.md
+++ b/doc/api_reference.md
@@ -63,7 +63,7 @@
 | POST | `/api/branches/<branch_id>/config` | 更新分支設定（merge，回傳含 `defaults`） | 任意 JSON（常用：`team_mode`, `image_gen_enabled`, `image_model`） |
 | POST | `/api/branches/edit` | 編輯歷史玩家訊息並生成新分支 | body: `parent_branch_id`, `branch_point_index`, `edited_message` |
 | POST | `/api/branches/edit/stream` | `edit` 的 SSE 版本 | 同上 |
-| POST | `/api/branches/regenerate` | 對既有玩家訊息重生成 GM 回覆（新分支） | body: `parent_branch_id`, `branch_point_index` |
+| POST | `/api/branches/regenerate` | 對既有玩家訊息重生成 GM 回覆（新分支；也可補發最後一則尚未有 GM 的玩家訊息） | body: `parent_branch_id`, `branch_point_index` |
 | POST | `/api/branches/regenerate/stream` | `regenerate` 的 SSE 版本 | 同上 |
 | POST | `/api/branches/promote` | Promote 某分支為主線路徑並剪枝 | body: `branch_id` |
 | POST | `/api/branches/merge` | 合併子分支回父分支 | body: `branch_id` |
@@ -74,7 +74,7 @@
 
 `/api/branches/edit*` / `/api/branches/regenerate*` 補充：
 - `edit` 的 `branch_point_index + 1` 必須命中一則既有 `user` 訊息，否則回 `invalid_edit_target`
-- `regenerate` 的 `branch_point_index` 必須命中一則既有 `user` 訊息，且其下一則必須是 `gm`，否則回 `invalid_regenerate_target`
+- `regenerate` 的 `branch_point_index` 必須命中一則既有 `user` 訊息；若下一則存在，必須是 `gm`。特例是它也接受「目前時間線最後一則、尚未有 GM 回覆」的 `user` 訊息作為補發目標，其他情況仍回 `invalid_regenerate_target`
 
 ## 故事（Story）管理
 

--- a/doc/game_mechanics.md
+++ b/doc/game_mechanics.md
@@ -244,6 +244,7 @@
 ### 8.1 Edit / Regenerate
 
 - 都會建立新分支，不覆蓋原分支
+- `regenerate` 除了重生既有 `user -> GM` 配對，也接受「最後一則已落盤但尚未有 GM」的 `user` 回合作為補發目標
 - 新分支會繼承：
   - 對應 index 的 state/NPC/world_day snapshot
   - recap、cheat、branch lore、events、dungeon progress、gm plan（若 `plan.updated_at_index <= branch_point_index`）

--- a/routes/branch_routes.py
+++ b/routes/branch_routes.py
@@ -19,6 +19,28 @@ def _app():
     return app_module
 
 
+def _resolve_regenerate_user_message(app_module, timeline: list[dict], branch_point_index: int) -> dict | None:
+    """Allow regenerating a user turn with an existing GM reply or retrying the last persisted user turn."""
+    user_msg = app_module._find_timeline_message(timeline, branch_point_index, role="user")
+    if not user_msg:
+        return None
+
+    next_msg = app_module._find_timeline_message(timeline, branch_point_index + 1)
+    if next_msg is not None:
+        if next_msg.get("role") in ("gm", "assistant"):
+            return user_msg
+        return None
+
+    has_later_messages = any(
+        isinstance(message, dict) and isinstance(message.get("index"), int)
+        and message["index"] > branch_point_index
+        for message in timeline
+    )
+    if has_later_messages:
+        return None
+    return user_msg
+
+
 @branch_bp.route("/api/branches")
 def api_branches():
     app_module = _app()
@@ -927,11 +949,8 @@ def api_branches_regenerate():
     branches = tree.get("branches", {})
     source_branch_id = parent_branch_id
     source_timeline = app_module.get_full_timeline(story_id, source_branch_id)
-    user_msg = app_module._find_timeline_message(source_timeline, branch_point_index, role="user")
-    gm_msg = app_module._find_timeline_message(
-        source_timeline, branch_point_index + 1, role=("gm", "assistant")
-    )
-    if not user_msg or not gm_msg:
+    user_msg = _resolve_regenerate_user_message(app_module, source_timeline, branch_point_index)
+    if not user_msg:
         return jsonify({"ok": False, "error": "invalid_regenerate_target"}), 400
     parent_branch_id = app_module._resolve_sibling_parent(branches, parent_branch_id, branch_point_index)
     if parent_branch_id not in branches:
@@ -1105,11 +1124,8 @@ def api_branches_regenerate_stream():
     branches = tree.get("branches", {})
     source_branch_id = parent_branch_id
     source_timeline = app_module.get_full_timeline(story_id, source_branch_id)
-    user_msg = app_module._find_timeline_message(source_timeline, branch_point_index, role="user")
-    gm_msg = app_module._find_timeline_message(
-        source_timeline, branch_point_index + 1, role=("gm", "assistant")
-    )
-    if not user_msg or not gm_msg:
+    user_msg = _resolve_regenerate_user_message(app_module, source_timeline, branch_point_index)
+    if not user_msg:
         return Response(
             app_module._sse_event({"type": "error", "message": "invalid_regenerate_target"}),
             mimetype="text/event-stream",

--- a/static/app.js
+++ b/static/app.js
@@ -1927,6 +1927,7 @@ async function regenerateGmMessage(msg, msgEl) {
 
   const parentBranchId = msg.owner_branch_id || currentBranchId;
   const branchPointIndex = (msg.role === 'user') ? msg.index : msg.index - 1;
+  const retryingMissingGm = msg.role === 'user';
 
   // Truncate subsequent messages in DOM
   let sibling = msgEl.nextSibling;
@@ -2002,8 +2003,13 @@ async function regenerateGmMessage(msg, msgEl) {
       // onError
       (errMsg) => {
         if (errMsg !== "AbortError") {
-          if (contentEl) contentEl.innerHTML = markdownToHtml(msg.content);
-          if (actionsEl) actionsEl.style.display = "";
+          if (retryingMissingGm) {
+            if (targetMsgEl) targetMsgEl.remove();
+            appendSystemError(errMsg || "重新生成失敗");
+          } else {
+            if (contentEl) contentEl.innerHTML = markdownToHtml(msg.content);
+            if (actionsEl) actionsEl.style.display = "";
+          }
           loadBranches().then(() => renderBranchList());
           showAlert(errMsg || "重新生成失敗");
         }
@@ -2013,8 +2019,13 @@ async function regenerateGmMessage(msg, msgEl) {
     );
   } catch (err) {
     if (err.name === 'AbortError') return;
-    if (contentEl) contentEl.innerHTML = markdownToHtml(msg.content);
-    if (actionsEl) actionsEl.style.display = "";
+    if (retryingMissingGm) {
+      if (targetMsgEl) targetMsgEl.remove();
+      appendSystemError("網路錯誤：" + err.message);
+    } else {
+      if (contentEl) contentEl.innerHTML = markdownToHtml(msg.content);
+      if (actionsEl) actionsEl.style.display = "";
+    }
     showAlert("網路錯誤：" + err.message);
   }
 

--- a/static/app.js
+++ b/static/app.js
@@ -1968,7 +1968,9 @@ async function regenerateGmMessage(msg, msgEl) {
 
   $sendBtn.disabled = true;
 
-  showPlaceholderSwitcher(targetMsgEl, branchPointIndex + 1);
+  showPlaceholderSwitcher(targetMsgEl, branchPointIndex + 1, {
+    baseVariantCount: retryingMissingGm ? 1 : 2,
+  });
 
   if (activeStreamController) {
     activeStreamController.abort();
@@ -2033,10 +2035,11 @@ async function regenerateGmMessage(msg, msgEl) {
 }
 
 
-function showPlaceholderSwitcher(msgEl, index) {
+function showPlaceholderSwitcher(msgEl, index, options = {}) {
   const sibKey = String(index);
-  let current = 2;
-  let total = 2;
+  const baseVariantCount = Math.max(1, Number(options.baseVariantCount) || 2);
+  let current = baseVariantCount;
+  let total = baseVariantCount;
 
   if (siblingGroups[sibKey]) {
     total = siblingGroups[sibKey].total + 1;

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -1029,6 +1029,62 @@ class TestDungeonAPI:
         assert resp.status_code == 200
         assert calls == [("test_story", "main", 2)]
 
+    def test_regenerate_allows_retry_for_last_user_without_gm(self, client, setup_story, monkeypatch):
+        """Regenerate should accept the last persisted user turn when GM generation previously failed."""
+        import app as app_module
+
+        messages_path = setup_story / "branches" / "main" / "messages.json"
+        messages_path.write_text(
+            json.dumps([{"index": 4, "role": "user", "content": "補發這一回合"}], ensure_ascii=False),
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr(app_module, "call_claude_gm", lambda *a, **kw: ("補發成功", None))
+        monkeypatch.setattr(app_module, "_extract_tags_async", lambda *a, **kw: None)
+
+        resp = client.post("/api/branches/regenerate", json={
+            "parent_branch_id": "main",
+            "branch_point_index": 4,
+        })
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["ok"] is True
+        assert data["gm_msg"]["index"] == 5
+        assert data["gm_msg"]["content"] == "補發成功"
+
+    def test_regenerate_stream_allows_retry_for_last_user_without_gm(self, client, setup_story, monkeypatch):
+        """Streaming regenerate should accept the last persisted user turn when no GM reply exists yet."""
+        import app as app_module
+
+        messages_path = setup_story / "branches" / "main" / "messages.json"
+        messages_path.write_text(
+            json.dumps([{"index": 4, "role": "user", "content": "補發這一回合"}], ensure_ascii=False),
+            encoding="utf-8",
+        )
+
+        def fake_call_claude_gm_stream(_user_text, _system_prompt, _recent, session_id=None, **kwargs):
+            assert session_id is None
+            assert kwargs["branch_id"].startswith("branch_")
+            yield ("done", {"response": "補發串流成功", "usage": None})
+
+        monkeypatch.setattr(app_module, "call_claude_gm_stream", fake_call_claude_gm_stream)
+        monkeypatch.setattr(
+            app_module,
+            "_process_gm_response",
+            lambda gm_response, _story_id, _branch_id, _idx, **_kwargs: (gm_response, None, {}),
+        )
+
+        resp = client.post("/api/branches/regenerate/stream", json={
+            "parent_branch_id": "main",
+            "branch_point_index": 4,
+        })
+
+        assert resp.status_code == 200
+        data = resp.get_data(as_text=True)
+        assert "\"type\": \"done\"" in data
+        assert "\"補發串流成功\"" in data
+
     def test_edit_stream_no_change_rejected(self, client, setup_story):
         """Streaming edit with identical content should return error SSE event."""
         resp = client.post("/api/branches/edit/stream", json={

--- a/tests/test_api_routes.py
+++ b/tests/test_api_routes.py
@@ -1065,7 +1065,6 @@ class TestDungeonAPI:
 
         def fake_call_claude_gm_stream(_user_text, _system_prompt, _recent, session_id=None, **kwargs):
             assert session_id is None
-            assert kwargs["branch_id"].startswith("branch_")
             yield ("done", {"response": "補發串流成功", "usage": None})
 
         monkeypatch.setattr(app_module, "call_claude_gm_stream", fake_call_claude_gm_stream)


### PR DESCRIPTION
## Summary\n- allow branch regenerate to retry the last persisted user turn when the GM reply is missing\n- keep the streaming and non-stream regenerate routes aligned and update the related docs\n- clean up the retry UI so a failed retry removes the temporary GM bubble instead of leaving stale content\n\n## Testing\n- pytest tests/test_api_routes.py